### PR TITLE
Add accounting report exports and FEC support

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -22,6 +22,7 @@
     "fastify": "5.6.0",
     "fastify-plugin": "5.0.1",
     "jsonwebtoken": "9.0.2",
+    "pdf-lib": "1.17.1",
     "pino": "9.11.0",
     "redis": "5.8.2",
     "zod": "4.1.11"
@@ -29,6 +30,7 @@
   "devDependencies": {
     "@types/jsonwebtoken": "9.0.7",
     "@types/node": "24.5.2",
+    "@types/supertest": "2.0.16",
     "@types/pg": "8.11.6",
     "esbuild-register": "3.6.0",
     "pg": "8.13.1",

--- a/apps/api/prisma/migrations/20250926093000_add_fec_export/migration.sql
+++ b/apps/api/prisma/migrations/20250926093000_add_fec_export/migration.sql
@@ -1,0 +1,35 @@
+BEGIN;
+
+CREATE TABLE "public"."fec_export" (
+    "id" UUID NOT NULL DEFAULT uuid_generate_v7(),
+    "organization_id" UUID NOT NULL,
+    "fiscal_year_id" UUID NOT NULL,
+    "checksum" TEXT NOT NULL,
+    "generated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "fec_export_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "fec_export_org_year_idx" ON "public"."fec_export"("organization_id", "fiscal_year_id");
+
+ALTER TABLE "public"."fec_export"
+    ADD CONSTRAINT "fec_export_organization_id_fkey"
+    FOREIGN KEY ("organization_id")
+    REFERENCES "public"."organization"("id")
+    ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "public"."fec_export"
+    ADD CONSTRAINT "fec_export_fiscal_year_id_fkey"
+    FOREIGN KEY ("fiscal_year_id")
+    REFERENCES "public"."fiscal_year"("id")
+    ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "public"."fec_export" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."fec_export" FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY "fec_export_isolation" ON "public"."fec_export"
+  FOR ALL
+  USING ("organization_id" = current_setting('app.current_org')::uuid)
+  WITH CHECK ("organization_id" = current_setting('app.current_org')::uuid);
+
+COMMIT;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -21,6 +21,7 @@ model Organization {
   memberships UserOrgRole[]
   refreshTokens RefreshToken[]
   sequences   SequenceNumber[]
+  fecExports  FecExport[]
 
   @@map("organization")
 }
@@ -37,6 +38,7 @@ model FiscalYear {
   organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Restrict)
   entries        Entry[]
   sequences      SequenceNumber[]
+  fecExports     FecExport[]
 
   @@unique([organizationId, label], map: "fiscal_year_org_label_key")
   @@index([organizationId, startDate], map: "fiscal_year_org_start_idx")
@@ -115,6 +117,19 @@ model SequenceNumber {
 
   @@unique([organizationId, fiscalYearId, journalId], map: "sequence_number_org_year_journal_key")
   @@map("sequence_number")
+}
+
+model FecExport {
+  id             String       @id @default(dbgenerated("uuid_generate_v7()")) @db.Uuid
+  organizationId String       @map("organization_id") @db.Uuid
+  fiscalYearId   String       @map("fiscal_year_id") @db.Uuid
+  checksum       String
+  generatedAt    DateTime     @default(now()) @map("generated_at")
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Restrict)
+  fiscalYear     FiscalYear   @relation(fields: [fiscalYearId], references: [id], onDelete: Restrict)
+
+  @@index([organizationId, fiscalYearId], map: "fec_export_org_year_idx")
+  @@map("fec_export")
 }
 
 model EntryLine {

--- a/apps/api/src/__tests__/helpers/database.ts
+++ b/apps/api/src/__tests__/helpers/database.ts
@@ -57,7 +57,7 @@ export async function resetDatabase(): Promise<void> {
   const adminClient = new PgClient({ connectionString: buildAdminDatabaseUrl(currentDatabaseName) });
   await adminClient.connect();
   await adminClient.query(
-    'TRUNCATE TABLE "refresh_token", "user_org_role", "user", "attachment", "entry_line", "entry", "sequence_number", "journal", "account", "fiscal_year", "organization" RESTART IDENTITY CASCADE'
+    'TRUNCATE TABLE "refresh_token", "user_org_role", "user", "attachment", "fec_export", "entry_line", "entry", "sequence_number", "journal", "account", "fiscal_year", "organization" RESTART IDENTITY CASCADE'
   );
   await adminClient.end();
 }
@@ -218,5 +218,7 @@ function isConcurrentUpdateError(error: unknown): boolean {
   }
 
   const pgError = error as PgError;
-  return pgError.code === '40001' || pgError.message?.includes('tuple concurrently updated');
+  const messageIndicatesConcurrency =
+    typeof pgError.message === 'string' && pgError.message.includes('tuple concurrently updated');
+  return pgError.code === '40001' || messageIndicatesConcurrency;
 }

--- a/apps/api/src/__tests__/reports.http.test.ts
+++ b/apps/api/src/__tests__/reports.http.test.ts
@@ -1,0 +1,389 @@
+import { createHash } from 'node:crypto';
+import type { FastifyInstance } from 'fastify';
+import request from 'supertest';
+import type { Response as SuperAgentResponse } from 'superagent';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { Prisma, PrismaClient, UserRole } from '@prisma/client';
+import buildServer from '../server';
+import {
+  applyTenantContext,
+  createPrismaClient,
+  resetDatabase,
+  setupTestDatabase,
+  teardownTestDatabase,
+} from './helpers/database';
+
+const TEST_ACCESS_SECRET = 'test-access-secret-change-me-12345678901234567890';
+const TEST_REFRESH_SECRET = 'test-refresh-secret-change-me-12345678901234567890';
+
+let app: FastifyInstance;
+let prisma: PrismaClient;
+
+beforeAll(async () => {
+  process.env.JWT_ACCESS_SECRET = TEST_ACCESS_SECRET;
+  process.env.JWT_REFRESH_SECRET = TEST_REFRESH_SECRET;
+  process.env.REFRESH_TOKEN_TTL_DAYS = '30';
+  process.env.NODE_ENV = 'test';
+
+  await setupTestDatabase();
+
+  prisma = createPrismaClient();
+  await prisma.$connect();
+
+  app = await buildServer();
+  await app.ready();
+});
+
+afterAll(async () => {
+  await app.close();
+  await prisma.$disconnect();
+  await teardownTestDatabase();
+});
+
+beforeEach(async () => {
+  await resetDatabase();
+});
+
+describe('accounting reports HTTP routes', () => {
+  it('returns the trial balance with totals and exports CSV/PDF', async () => {
+    const { organizationId, accessToken } = await createUserWithRole(UserRole.TREASURER);
+    const fixtures = await seedReportFixtures(organizationId, { lockFiscalYear: true });
+
+    const response = await request(app.server)
+      .get(`/api/v1/orgs/${organizationId}/reports/balance`)
+      .query({ fiscalYearId: fixtures.fiscalYear.id })
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(response.statusCode).toBe(200);
+    const report = response.body.data as TrialBalanceResponse;
+    expect(report.lines).toHaveLength(3);
+
+    const bankLine = report.lines.find((line) => line.code === fixtures.bankAccount.code);
+    const revenueLine = report.lines.find((line) => line.code === fixtures.revenueAccount.code);
+    const expenseLine = report.lines.find((line) => line.code === fixtures.expenseAccount.code);
+
+    expect(bankLine?.debit).toBeCloseTo(700);
+    expect(bankLine?.credit).toBeCloseTo(170);
+    expect(revenueLine?.credit).toBeCloseTo(700);
+    expect(expenseLine?.debit).toBeCloseTo(170);
+    expect(report.totals.debit).toBeCloseTo(870);
+    expect(report.totals.credit).toBeCloseTo(870);
+
+    const csvResponse = await request(app.server)
+      .get(`/api/v1/orgs/${organizationId}/reports/balance`)
+      .query({ fiscalYearId: fixtures.fiscalYear.id, format: 'csv' })
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(csvResponse.statusCode).toBe(200);
+    expect(csvResponse.headers['content-type']).toContain('text/csv');
+    expect(csvResponse.text).toContain('Account Code;Account Name;Debit;Credit;Balance');
+    expect(csvResponse.text).toContain(
+      `${fixtures.bankAccount.code};${fixtures.bankAccount.name};700.00;170.00;530.00`
+    );
+
+    const pdfResponse = await request(app.server)
+      .get(`/api/v1/orgs/${organizationId}/reports/balance`)
+      .query({ fiscalYearId: fixtures.fiscalYear.id, format: 'pdf' })
+      .set('Authorization', `Bearer ${accessToken}`)
+      .buffer(true)
+      .parse(binaryParser);
+
+    expect(pdfResponse.statusCode).toBe(200);
+    expect(pdfResponse.headers['content-type']).toBe('application/pdf');
+    const pdfBuffer = pdfResponse.body as Buffer;
+    expect(pdfBuffer.subarray(0, 4).toString()).toBe('%PDF');
+  });
+
+  it('returns the general ledger with running balances and exports CSV', async () => {
+    const { organizationId, accessToken } = await createUserWithRole(UserRole.TREASURER);
+    const fixtures = await seedReportFixtures(organizationId, { lockFiscalYear: true });
+
+    const response = await request(app.server)
+      .get(`/api/v1/orgs/${organizationId}/reports/ledger`)
+      .query({ fiscalYearId: fixtures.fiscalYear.id })
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(response.statusCode).toBe(200);
+    const ledger = response.body.data as LedgerResponse;
+    expect(ledger.accounts).toHaveLength(3);
+
+    const bankAccount = ledger.accounts.find((account) => account.code === fixtures.bankAccount.code);
+    expect(bankAccount?.movements).toHaveLength(4);
+    expect(bankAccount?.movements[0].debit).toBeCloseTo(500);
+    expect(bankAccount?.movements[1].credit).toBeCloseTo(120);
+    expect(bankAccount?.movements[3].balance).toBeCloseTo(530);
+
+    const csvResponse = await request(app.server)
+      .get(`/api/v1/orgs/${organizationId}/reports/ledger`)
+      .query({ fiscalYearId: fixtures.fiscalYear.id, format: 'csv' })
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(csvResponse.statusCode).toBe(200);
+    expect(csvResponse.headers['content-type']).toContain('text/csv');
+    expect(csvResponse.text).toContain('Account Code;Account Name;Date;Journal;Reference;Memo;Debit;Credit;Balance');
+    expect(csvResponse.text).toContain('706000;Cotisations;2025-01-10;BAN - Banque;E2025-0001;Cotisations Janvier;0.00;500.00;-500.00');
+  });
+
+  it('returns the income statement with net result and exports PDF', async () => {
+    const { organizationId, accessToken } = await createUserWithRole(UserRole.TREASURER);
+    const fixtures = await seedReportFixtures(organizationId, { lockFiscalYear: true });
+
+    const response = await request(app.server)
+      .get(`/api/v1/orgs/${organizationId}/reports/income`)
+      .query({ fiscalYearId: fixtures.fiscalYear.id })
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(response.statusCode).toBe(200);
+    const income = response.body.data as IncomeStatementResponse;
+    expect(income.rows).toHaveLength(2);
+
+    const revenueRow = income.rows.find((row) => row.type === 'REVENUE');
+    const expenseRow = income.rows.find((row) => row.type === 'EXPENSE');
+
+    expect(revenueRow?.result).toBeCloseTo(700);
+    expect(expenseRow?.result).toBeCloseTo(170);
+    expect(income.totals.net).toBeCloseTo(530);
+
+    const pdfResponse = await request(app.server)
+      .get(`/api/v1/orgs/${organizationId}/reports/income`)
+      .query({ fiscalYearId: fixtures.fiscalYear.id, format: 'pdf' })
+      .set('Authorization', `Bearer ${accessToken}`)
+      .buffer(true)
+      .parse(binaryParser);
+
+    expect(pdfResponse.statusCode).toBe(200);
+    expect(pdfResponse.headers['content-type']).toBe('application/pdf');
+    const pdfBuffer = pdfResponse.body as Buffer;
+    expect(pdfBuffer.subarray(0, 4).toString()).toBe('%PDF');
+  });
+
+  it('generates a compliant FEC export with checksum stored in the database', async () => {
+    const { organizationId, accessToken } = await createUserWithRole(UserRole.TREASURER);
+    const fixtures = await seedReportFixtures(organizationId, { lockFiscalYear: true });
+
+    const response = await request(app.server)
+      .get(`/api/v1/orgs/${organizationId}/reports/fec`)
+      .query({ fiscalYearId: fixtures.fiscalYear.id })
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['content-type']).toContain('text/csv');
+
+    const lines = response.text.trim().split('\n');
+    expect(lines[0]).toBe(
+      'JournalCode;JournalLib;EcritureNum;EcritureDate;CompteNum;CompteLib;CompAuxNum;CompAuxLib;PieceRef;PieceDate;EcritureLib;Debit;Credit;EcritureLet;DateLet;ValidDate;Montantdevise;Idevise'
+    );
+    expect(lines).toHaveLength(9);
+
+    const firstRow = lines[1].split(';');
+    expect(firstRow[0]).toBe('BAN');
+    expect(firstRow[1]).toBe('Banque');
+    expect(firstRow[2]).toBe('E2025-0001');
+    expect(firstRow[3]).toBe('20250110');
+    expect(firstRow[4]).toBe('512000');
+    expect(firstRow[5]).toBe('Banque');
+    expect(firstRow[10]).toBe('Cotisations Janvier');
+    expect(firstRow[11]).toBe('500.00');
+    expect(firstRow[12]).toBe('0.00');
+
+    const checksum = createHash('sha256').update(response.text, 'utf8').digest('hex');
+    expect(response.headers['x-report-checksum']).toBe(checksum);
+
+    const fecExports = await prisma.$transaction(async (tx) => {
+      await applyTenantContext(tx, organizationId);
+      return tx.fecExport.findMany({ where: { fiscalYearId: fixtures.fiscalYear.id } });
+    });
+
+    expect(fecExports).toHaveLength(1);
+    expect(fecExports[0].checksum).toBe(checksum);
+  });
+
+  it('rejects FEC export when the fiscal year is not locked', async () => {
+    const { organizationId, accessToken } = await createUserWithRole(UserRole.TREASURER);
+    const fixtures = await seedReportFixtures(organizationId, { lockFiscalYear: false });
+
+    const response = await request(app.server)
+      .get(`/api/v1/orgs/${organizationId}/reports/fec`)
+      .query({ fiscalYearId: fixtures.fiscalYear.id })
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(response.statusCode).toBe(403);
+    expect(response.body.title).toBe('FISCAL_YEAR_NOT_LOCKED');
+  });
+});
+
+interface TrialBalanceResponse {
+  lines: Array<{
+    code: string;
+    debit: number;
+    credit: number;
+    balance: number;
+  }>;
+  totals: {
+    debit: number;
+    credit: number;
+    balance: number;
+  };
+}
+
+interface LedgerResponse {
+  accounts: Array<{
+    code: string;
+    movements: Array<{
+      debit: number;
+      credit: number;
+      balance: number;
+    }>;
+  }>;
+}
+
+interface IncomeStatementResponse {
+  rows: Array<{
+    type: 'REVENUE' | 'EXPENSE';
+    result: number;
+  }>;
+  totals: {
+    revenue: number;
+    expense: number;
+    net: number;
+  };
+}
+
+async function createUserWithRole(role: UserRole) {
+  const organization = await prisma.organization.create({ data: { name: `Org ${Date.now()}` } });
+  const user = await prisma.user.create({
+    data: {
+      email: `user+${Math.random().toString(16).slice(2)}@example.org`,
+      passwordHash: 'test-hash',
+    },
+  });
+
+  await prisma.userOrgRole.create({
+    data: {
+      organizationId: organization.id,
+      userId: user.id,
+      role,
+    },
+  });
+
+  const accessToken = app.issueAccessToken({
+    userId: user.id,
+    organizationId: organization.id,
+    roles: [role],
+  });
+
+  return { organizationId: organization.id, accessToken };
+}
+
+interface ReportFixtureOptions {
+  lockFiscalYear?: boolean;
+}
+
+async function seedReportFixtures(organizationId: string, options: ReportFixtureOptions = {}) {
+  return prisma.$transaction(async (tx) => {
+    await applyTenantContext(tx, organizationId);
+
+    const fiscalYear = await tx.fiscalYear.create({
+      data: {
+        organizationId,
+        label: 'FY2025',
+        startDate: new Date('2025-01-01'),
+        endDate: new Date('2025-12-31'),
+        lockedAt: options.lockFiscalYear ? new Date('2025-12-31T23:59:59Z') : null,
+      },
+    });
+
+    const journal = await tx.journal.create({
+      data: {
+        organizationId,
+        code: 'BAN',
+        name: 'Banque',
+        type: 'BANK',
+      },
+    });
+
+    const bankAccount = await tx.account.create({
+      data: {
+        organizationId,
+        code: '512000',
+        name: 'Banque',
+        type: 'ASSET',
+      },
+    });
+
+    const revenueAccount = await tx.account.create({
+      data: {
+        organizationId,
+        code: '706000',
+        name: 'Cotisations',
+        type: 'REVENUE',
+      },
+    });
+
+    const expenseAccount = await tx.account.create({
+      data: {
+        organizationId,
+        code: '606000',
+        name: 'Fournitures',
+        type: 'EXPENSE',
+      },
+    });
+
+    const createEntry = (
+      date: string,
+      reference: string,
+      memo: string,
+      lines: Array<{ accountId: string; debit?: string; credit?: string }>
+    ) =>
+      tx.entry.create({
+        data: {
+          organizationId,
+          fiscalYearId: fiscalYear.id,
+          journalId: journal.id,
+          date: new Date(date),
+          reference,
+          memo,
+          lines: {
+            create: lines.map((line) => ({
+              organizationId,
+              accountId: line.accountId,
+              debit: new Prisma.Decimal(line.debit ?? '0'),
+              credit: new Prisma.Decimal(line.credit ?? '0'),
+            })),
+          },
+        },
+      });
+
+    await createEntry('2025-01-10', 'E2025-0001', 'Cotisations Janvier', [
+      { accountId: bankAccount.id, debit: '500.00' },
+      { accountId: revenueAccount.id, credit: '500.00' },
+    ]);
+
+    await createEntry('2025-02-05', 'E2025-0002', 'Achat fournitures', [
+      { accountId: expenseAccount.id, debit: '120.00' },
+      { accountId: bankAccount.id, credit: '120.00' },
+    ]);
+
+    await createEntry('2025-03-15', 'E2025-0003', 'Cotisations Mars', [
+      { accountId: bankAccount.id, debit: '200.00' },
+      { accountId: revenueAccount.id, credit: '200.00' },
+    ]);
+
+    await createEntry('2025-04-20', 'E2025-0004', 'Achat papeterie', [
+      { accountId: expenseAccount.id, debit: '50.00' },
+      { accountId: bankAccount.id, credit: '50.00' },
+    ]);
+
+    return { fiscalYear, journal, bankAccount, revenueAccount, expenseAccount };
+  });
+}
+
+function binaryParser(
+  res: SuperAgentResponse,
+  callback: (err: Error | null, data: Buffer) => void
+): void {
+  const chunks: Buffer[] = [];
+  res.on('data', (chunk) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)));
+  res.on('end', () => callback(null, Buffer.concat(chunks)));
+  res.on('error', (error) => callback(error as Error, Buffer.alloc(0)));
+}

--- a/apps/api/src/modules/accounting/reports/index.ts
+++ b/apps/api/src/modules/accounting/reports/index.ts
@@ -1,0 +1,1 @@
+export * from './service';

--- a/apps/api/src/modules/accounting/reports/service.ts
+++ b/apps/api/src/modules/accounting/reports/service.ts
@@ -1,0 +1,647 @@
+import { createHash } from 'node:crypto';
+import { Prisma, type PrismaClient } from '@prisma/client';
+import { HttpProblemError } from '../../../lib/problem-details';
+
+export type ReportClient = PrismaClient | Prisma.TransactionClient;
+
+export interface FiscalYearSummary {
+  id: string;
+  label: string;
+  startDate: string;
+  endDate: string;
+  lockedAt: string | null;
+}
+
+export interface JournalReportLine {
+  lineId: string;
+  accountId: string;
+  accountCode: string;
+  accountName: string;
+  debit: number;
+  credit: number;
+}
+
+export interface JournalReportEntry {
+  entryId: string;
+  date: string;
+  reference: string | null;
+  memo: string | null;
+  journal: {
+    id: string;
+    code: string;
+    name: string;
+  };
+  lines: JournalReportLine[];
+  totals: {
+    debit: number;
+    credit: number;
+  };
+}
+
+export interface JournalReport {
+  fiscalYear: FiscalYearSummary;
+  entries: JournalReportEntry[];
+  totals: {
+    debit: number;
+    credit: number;
+  };
+}
+
+export interface LedgerReportMovement {
+  lineId: string;
+  entryId: string;
+  date: string;
+  reference: string | null;
+  journalCode: string;
+  journalName: string;
+  memo: string | null;
+  debit: number;
+  credit: number;
+  balance: number;
+}
+
+export interface LedgerReportAccount {
+  accountId: string;
+  code: string;
+  name: string;
+  totalDebit: number;
+  totalCredit: number;
+  balance: number;
+  movements: LedgerReportMovement[];
+}
+
+export interface LedgerReport {
+  fiscalYear: FiscalYearSummary;
+  accounts: LedgerReportAccount[];
+  totals: {
+    debit: number;
+    credit: number;
+  };
+}
+
+export interface TrialBalanceLine {
+  accountId: string;
+  code: string;
+  name: string;
+  type: string;
+  debit: number;
+  credit: number;
+  balance: number;
+}
+
+export interface TrialBalanceReport {
+  fiscalYear: FiscalYearSummary;
+  lines: TrialBalanceLine[];
+  totals: {
+    debit: number;
+    credit: number;
+    balance: number;
+  };
+}
+
+export interface IncomeStatementRow {
+  accountId: string;
+  code: string;
+  name: string;
+  type: 'REVENUE' | 'EXPENSE';
+  debit: number;
+  credit: number;
+  balance: number;
+  result: number;
+}
+
+export interface IncomeStatementReport {
+  fiscalYear: FiscalYearSummary;
+  rows: IncomeStatementRow[];
+  totals: {
+    revenue: number;
+    expense: number;
+    net: number;
+  };
+}
+
+export interface FecGenerationResult {
+  fiscalYear: FiscalYearSummary;
+  csv: string;
+  checksum: string;
+  rowCount: number;
+}
+
+const FEC_COLUMNS = [
+  'JournalCode',
+  'JournalLib',
+  'EcritureNum',
+  'EcritureDate',
+  'CompteNum',
+  'CompteLib',
+  'CompAuxNum',
+  'CompAuxLib',
+  'PieceRef',
+  'PieceDate',
+  'EcritureLib',
+  'Debit',
+  'Credit',
+  'EcritureLet',
+  'DateLet',
+  'ValidDate',
+  'Montantdevise',
+  'Idevise',
+] as const;
+
+const ZERO = new Prisma.Decimal(0);
+
+export async function getJournalReport(
+  client: ReportClient,
+  organizationId: string,
+  fiscalYearId: string
+): Promise<JournalReport> {
+  const fiscalYear = await getFiscalYearOrThrow(client, organizationId, fiscalYearId);
+
+  const entries = await client.entry.findMany({
+    where: { organizationId, fiscalYearId },
+    orderBy: [
+      { date: 'asc' },
+      { reference: 'asc' },
+      { id: 'asc' },
+    ],
+    include: {
+      journal: {
+        select: { id: true, code: true, name: true },
+      },
+      lines: {
+        orderBy: { id: 'asc' },
+        include: {
+          account: {
+            select: { id: true, code: true, name: true },
+          },
+        },
+      },
+    },
+  });
+
+  let reportDebit = ZERO;
+  let reportCredit = ZERO;
+
+  const entrySummaries = entries.map((entry) => {
+    let entryDebit = ZERO;
+    let entryCredit = ZERO;
+
+    const lines = entry.lines.map((line) => {
+      entryDebit = entryDebit.add(line.debit);
+      entryCredit = entryCredit.add(line.credit);
+
+      return {
+        lineId: line.id,
+        accountId: line.accountId,
+        accountCode: line.account.code,
+        accountName: line.account.name,
+        debit: decimalToNumber(line.debit),
+        credit: decimalToNumber(line.credit),
+      } satisfies JournalReportLine;
+    });
+
+    reportDebit = reportDebit.add(entryDebit);
+    reportCredit = reportCredit.add(entryCredit);
+
+    return {
+      entryId: entry.id,
+      date: toIsoDate(entry.date),
+      reference: entry.reference,
+      memo: entry.memo,
+      journal: {
+        id: entry.journal.id,
+        code: entry.journal.code,
+        name: entry.journal.name,
+      },
+      lines,
+      totals: {
+        debit: decimalToNumber(entryDebit),
+        credit: decimalToNumber(entryCredit),
+      },
+    } satisfies JournalReportEntry;
+  });
+
+  return {
+    fiscalYear: toFiscalYearSummary(fiscalYear),
+    entries: entrySummaries,
+    totals: {
+      debit: decimalToNumber(reportDebit),
+      credit: decimalToNumber(reportCredit),
+    },
+  } satisfies JournalReport;
+}
+
+export async function getLedgerReport(
+  client: ReportClient,
+  organizationId: string,
+  fiscalYearId: string
+): Promise<LedgerReport> {
+  const fiscalYear = await getFiscalYearOrThrow(client, organizationId, fiscalYearId);
+
+  const lines = await client.entryLine.findMany({
+    where: {
+      organizationId,
+      entry: { fiscalYearId },
+    },
+    orderBy: [
+      { account: { code: 'asc' } },
+      { entry: { date: 'asc' } },
+      { entry: { reference: 'asc' } },
+      { entry: { id: 'asc' } },
+      { id: 'asc' },
+    ],
+    include: {
+      account: { select: { id: true, code: true, name: true } },
+      entry: {
+        select: {
+          id: true,
+          date: true,
+          reference: true,
+          memo: true,
+          journal: { select: { code: true, name: true } },
+        },
+      },
+    },
+  });
+
+  const accountMap = new Map<string, {
+    id: string;
+    code: string;
+    name: string;
+    totalDebit: Prisma.Decimal;
+    totalCredit: Prisma.Decimal;
+    runningBalance: Prisma.Decimal;
+    movements: LedgerReportMovement[];
+  }>();
+
+  let overallDebit = ZERO;
+  let overallCredit = ZERO;
+
+  for (const line of lines) {
+    const existing = accountMap.get(line.accountId);
+
+    let accountState = existing;
+    if (!accountState) {
+      accountState = {
+        id: line.account.id,
+        code: line.account.code,
+        name: line.account.name,
+        totalDebit: ZERO,
+        totalCredit: ZERO,
+        runningBalance: ZERO,
+        movements: [],
+      };
+      accountMap.set(line.accountId, accountState);
+    }
+
+    accountState.totalDebit = accountState.totalDebit.add(line.debit);
+    accountState.totalCredit = accountState.totalCredit.add(line.credit);
+    accountState.runningBalance = accountState.runningBalance.add(line.debit).sub(line.credit);
+
+    const movement: LedgerReportMovement = {
+      lineId: line.id,
+      entryId: line.entry.id,
+      date: toIsoDate(line.entry.date),
+      reference: line.entry.reference,
+      journalCode: line.entry.journal.code,
+      journalName: line.entry.journal.name,
+      memo: line.entry.memo,
+      debit: decimalToNumber(line.debit),
+      credit: decimalToNumber(line.credit),
+      balance: decimalToNumber(accountState.runningBalance),
+    };
+
+    accountState.movements.push(movement);
+    overallDebit = overallDebit.add(line.debit);
+    overallCredit = overallCredit.add(line.credit);
+  }
+
+  const accounts = Array.from(accountMap.values())
+    .sort((a, b) => a.code.localeCompare(b.code))
+    .map((account) => ({
+      accountId: account.id,
+      code: account.code,
+      name: account.name,
+      totalDebit: decimalToNumber(account.totalDebit),
+      totalCredit: decimalToNumber(account.totalCredit),
+      balance: decimalToNumber(account.runningBalance),
+      movements: account.movements,
+    })) satisfies LedgerReportAccount[];
+
+  return {
+    fiscalYear: toFiscalYearSummary(fiscalYear),
+    accounts,
+    totals: {
+      debit: decimalToNumber(overallDebit),
+      credit: decimalToNumber(overallCredit),
+    },
+  } satisfies LedgerReport;
+}
+
+export async function getTrialBalanceReport(
+  client: ReportClient,
+  organizationId: string,
+  fiscalYearId: string
+): Promise<TrialBalanceReport> {
+  const fiscalYear = await getFiscalYearOrThrow(client, organizationId, fiscalYearId);
+
+  const grouped = await client.entryLine.groupBy({
+    by: ['accountId'],
+    where: {
+      organizationId,
+      entry: { fiscalYearId },
+    },
+    _sum: {
+      debit: true,
+      credit: true,
+    },
+  });
+
+  if (grouped.length === 0) {
+    return {
+      fiscalYear: toFiscalYearSummary(fiscalYear),
+      lines: [],
+      totals: { debit: 0, credit: 0, balance: 0 },
+    } satisfies TrialBalanceReport;
+  }
+
+  const accountIds = grouped.map((item) => item.accountId);
+  const accounts = await client.account.findMany({
+    where: { organizationId, id: { in: accountIds } },
+    select: { id: true, code: true, name: true, type: true },
+  });
+  const accountById = new Map(accounts.map((account) => [account.id, account]));
+
+  let totalDebit = ZERO;
+  let totalCredit = ZERO;
+
+  const lines = grouped
+    .map((item) => {
+      const account = accountById.get(item.accountId);
+      if (!account) {
+        return null;
+      }
+
+      const debit = (item._sum.debit ?? ZERO) as Prisma.Decimal;
+      const credit = (item._sum.credit ?? ZERO) as Prisma.Decimal;
+      const balance = debit.sub(credit);
+
+      totalDebit = totalDebit.add(debit);
+      totalCredit = totalCredit.add(credit);
+
+      return {
+        accountId: account.id,
+        code: account.code,
+        name: account.name,
+        type: account.type,
+        debit: decimalToNumber(debit),
+        credit: decimalToNumber(credit),
+        balance: decimalToNumber(balance),
+      } satisfies TrialBalanceLine;
+    })
+    .filter((line): line is TrialBalanceLine => line !== null)
+    .sort((a, b) => a.code.localeCompare(b.code));
+
+  const totalBalance = totalDebit.sub(totalCredit);
+
+  return {
+    fiscalYear: toFiscalYearSummary(fiscalYear),
+    lines,
+    totals: {
+      debit: decimalToNumber(totalDebit),
+      credit: decimalToNumber(totalCredit),
+      balance: decimalToNumber(totalBalance),
+    },
+  } satisfies TrialBalanceReport;
+}
+
+export async function getIncomeStatementReport(
+  client: ReportClient,
+  organizationId: string,
+  fiscalYearId: string
+): Promise<IncomeStatementReport> {
+  const fiscalYear = await getFiscalYearOrThrow(client, organizationId, fiscalYearId);
+
+  const accounts = await client.account.findMany({
+    where: {
+      organizationId,
+      type: { in: ['REVENUE', 'EXPENSE'] },
+      entryLines: { some: { entry: { fiscalYearId } } },
+    },
+    select: { id: true, code: true, name: true, type: true },
+    orderBy: { code: 'asc' },
+  });
+
+  if (accounts.length === 0) {
+    return {
+      fiscalYear: toFiscalYearSummary(fiscalYear),
+      rows: [],
+      totals: { revenue: 0, expense: 0, net: 0 },
+    } satisfies IncomeStatementReport;
+  }
+
+  const grouped = await client.entryLine.groupBy({
+    by: ['accountId'],
+    where: {
+      organizationId,
+      entry: { fiscalYearId },
+      account: { type: { in: ['REVENUE', 'EXPENSE'] } },
+    },
+    _sum: { debit: true, credit: true },
+  });
+  const groupByAccount = new Map(grouped.map((item) => [item.accountId, item]));
+
+  let revenueTotal = ZERO;
+  let expenseTotal = ZERO;
+
+  const rows = accounts.map((account) => {
+    const sums = groupByAccount.get(account.id);
+    const debit = (sums?._sum.debit ?? ZERO) as Prisma.Decimal;
+    const credit = (sums?._sum.credit ?? ZERO) as Prisma.Decimal;
+    const balance = debit.sub(credit);
+
+    if (account.type === 'REVENUE') {
+      revenueTotal = revenueTotal.add(credit.sub(debit));
+    } else {
+      expenseTotal = expenseTotal.add(debit.sub(credit));
+    }
+
+    return {
+      accountId: account.id,
+      code: account.code,
+      name: account.name,
+      type: account.type as 'REVENUE' | 'EXPENSE',
+      debit: decimalToNumber(debit),
+      credit: decimalToNumber(credit),
+      balance: decimalToNumber(balance),
+      result:
+        account.type === 'REVENUE'
+          ? decimalToNumber(credit.sub(debit))
+          : decimalToNumber(debit.sub(credit)),
+    } satisfies IncomeStatementRow;
+  });
+
+  const netResult = revenueTotal.sub(expenseTotal);
+
+  return {
+    fiscalYear: toFiscalYearSummary(fiscalYear),
+    rows,
+    totals: {
+      revenue: decimalToNumber(revenueTotal),
+      expense: decimalToNumber(expenseTotal),
+      net: decimalToNumber(netResult),
+    },
+  } satisfies IncomeStatementReport;
+}
+
+export async function generateFecReport(
+  client: ReportClient,
+  organizationId: string,
+  fiscalYearId: string
+): Promise<FecGenerationResult> {
+  const fiscalYear = await getFiscalYearOrThrow(client, organizationId, fiscalYearId);
+
+  if (!fiscalYear.lockedAt) {
+    throw new HttpProblemError({
+      status: 403,
+      title: 'FISCAL_YEAR_NOT_LOCKED',
+      detail: 'FEC export requires a locked fiscal year.',
+    });
+  }
+
+  const lines = await client.entryLine.findMany({
+    where: { organizationId, entry: { fiscalYearId } },
+    orderBy: [
+      { entry: { date: 'asc' } },
+      { entry: { reference: 'asc' } },
+      { entry: { id: 'asc' } },
+      { id: 'asc' },
+    ],
+    include: {
+      entry: {
+        select: {
+          id: true,
+          date: true,
+          reference: true,
+          memo: true,
+          journal: { select: { code: true, name: true } },
+        },
+      },
+      account: { select: { code: true, name: true } },
+    },
+  });
+
+  const rows = lines.map((line) => {
+    const entry = line.entry;
+    const account = line.account;
+    const entryRef = entry.reference ?? entry.id;
+    const entryDate = formatFecDate(entry.date);
+    const memo = entry.memo ?? account.name;
+
+    return [
+      entry.journal.code,
+      entry.journal.name,
+      entryRef,
+      entryDate,
+      account.code,
+      account.name,
+      '',
+      '',
+      entry.reference ?? '',
+      entryDate,
+      memo,
+      toFixed(line.debit),
+      toFixed(line.credit),
+      '',
+      '',
+      entryDate,
+      '',
+      '',
+    ];
+  });
+
+  const csvLines = [formatCsvRow(FEC_COLUMNS), ...rows.map((row) => formatCsvRow(row))];
+  const csv = csvLines.join('\n');
+  const checksum = createHash('sha256').update(csv, 'utf8').digest('hex');
+
+  await client.fecExport.create({
+    data: {
+      organizationId,
+      fiscalYearId,
+      checksum,
+    },
+  });
+
+  return {
+    fiscalYear: toFiscalYearSummary(fiscalYear),
+    csv,
+    checksum,
+    rowCount: rows.length,
+  } satisfies FecGenerationResult;
+}
+
+async function getFiscalYearOrThrow(
+  client: ReportClient,
+  organizationId: string,
+  fiscalYearId: string
+) {
+  const fiscalYear = await client.fiscalYear.findFirst({
+    where: { id: fiscalYearId, organizationId },
+  });
+
+  if (!fiscalYear) {
+    throw new HttpProblemError({
+      status: 404,
+      title: 'FISCAL_YEAR_NOT_FOUND',
+      detail: 'The specified fiscal year does not exist for this organization.',
+    });
+  }
+
+  return fiscalYear;
+}
+
+function toFiscalYearSummary(fiscalYear: {
+  id: string;
+  label: string;
+  startDate: Date;
+  endDate: Date;
+  lockedAt: Date | null;
+}): FiscalYearSummary {
+  return {
+    id: fiscalYear.id,
+    label: fiscalYear.label,
+    startDate: toIsoDate(fiscalYear.startDate),
+    endDate: toIsoDate(fiscalYear.endDate),
+    lockedAt: fiscalYear.lockedAt ? toIsoDate(fiscalYear.lockedAt) : null,
+  } satisfies FiscalYearSummary;
+}
+
+function decimalToNumber(decimal: Prisma.Decimal): number {
+  return Number(decimal.toFixed(2));
+}
+
+function toIsoDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function toFixed(value: Prisma.Decimal): string {
+  return value.toFixed(2);
+}
+
+function formatCsvRow(values: ReadonlyArray<string>): string {
+  return values
+    .map((value) => {
+      if (!value) {
+        return '';
+      }
+
+      const needsQuotes = /[";\n\r]/.test(value);
+      const sanitized = value.replace(/"/g, '""');
+      return needsQuotes ? `"${sanitized}"` : sanitized;
+    })
+    .join(';');
+}
+
+function formatFecDate(date: Date): string {
+  return date.toISOString().slice(0, 10).replace(/-/g, '');
+}

--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -1,0 +1,344 @@
+import type { FastifyPluginAsync } from 'fastify';
+import { z } from 'zod';
+import { UserRole } from '@prisma/client';
+import { PDFDocument, StandardFonts } from 'pdf-lib';
+import { HttpProblemError } from '../lib/problem-details';
+import {
+  generateFecReport,
+  getIncomeStatementReport,
+  getLedgerReport,
+  getTrialBalanceReport,
+  type IncomeStatementReport,
+  type LedgerReport,
+  type TrialBalanceReport,
+} from '../modules/accounting/reports';
+
+const organizationParamsSchema = z.object({
+  orgId: z.string().uuid(),
+});
+
+const reportQuerySchema = z.object({
+  fiscalYearId: z.string().uuid(),
+  format: z.enum(['json', 'csv', 'pdf']).default('json'),
+});
+
+const fecQuerySchema = z.object({
+  fiscalYearId: z.string().uuid(),
+});
+
+const reportsRoutes: FastifyPluginAsync = async (fastify) => {
+  const requireReportRole = fastify.authorizeRoles(
+    UserRole.ADMIN,
+    UserRole.TREASURER,
+    UserRole.SECRETARY,
+    UserRole.VIEWER
+  );
+  const requireFecRole = fastify.authorizeRoles(UserRole.ADMIN, UserRole.TREASURER);
+
+  fastify.get(
+    '/orgs/:orgId/reports/balance',
+    { preHandler: requireReportRole },
+    async (request, reply) => {
+      const { orgId } = organizationParamsSchema.parse(request.params);
+      const query = reportQuerySchema.parse(request.query);
+      ensureOrganizationAccess(request.user?.organizationId, orgId);
+
+      const report = await getTrialBalanceReport(request.prisma, orgId, query.fiscalYearId);
+
+      if (query.format === 'json') {
+        return { data: report };
+      }
+
+      if (query.format === 'csv') {
+        const csv = formatTrialBalanceCsv(report);
+        reply
+          .type('text/csv; charset=utf-8')
+          .header(
+            'Content-Disposition',
+            `attachment; filename="trial-balance-${report.fiscalYear.label}.csv"`
+          )
+          .send(csv);
+        return;
+      }
+
+      const pdf = await formatTrialBalancePdf(report);
+      reply
+        .type('application/pdf')
+        .header(
+          'Content-Disposition',
+          `attachment; filename="trial-balance-${report.fiscalYear.label}.pdf"`
+        )
+        .send(Buffer.from(pdf));
+    }
+  );
+
+  fastify.get(
+    '/orgs/:orgId/reports/ledger',
+    { preHandler: requireReportRole },
+    async (request, reply) => {
+      const { orgId } = organizationParamsSchema.parse(request.params);
+      const query = reportQuerySchema.parse(request.query);
+      ensureOrganizationAccess(request.user?.organizationId, orgId);
+
+      const report = await getLedgerReport(request.prisma, orgId, query.fiscalYearId);
+
+      if (query.format === 'json') {
+        return { data: report };
+      }
+
+      if (query.format === 'csv') {
+        const csv = formatLedgerCsv(report);
+        reply
+          .type('text/csv; charset=utf-8')
+          .header(
+            'Content-Disposition',
+            `attachment; filename="general-ledger-${report.fiscalYear.label}.csv"`
+          )
+          .send(csv);
+        return;
+      }
+
+      const pdf = await formatLedgerPdf(report);
+      reply
+        .type('application/pdf')
+        .header(
+          'Content-Disposition',
+          `attachment; filename="general-ledger-${report.fiscalYear.label}.pdf"`
+        )
+        .send(Buffer.from(pdf));
+    }
+  );
+
+  fastify.get(
+    '/orgs/:orgId/reports/income',
+    { preHandler: requireReportRole },
+    async (request, reply) => {
+      const { orgId } = organizationParamsSchema.parse(request.params);
+      const query = reportQuerySchema.parse(request.query);
+      ensureOrganizationAccess(request.user?.organizationId, orgId);
+
+      const report = await getIncomeStatementReport(request.prisma, orgId, query.fiscalYearId);
+
+      if (query.format === 'json') {
+        return { data: report };
+      }
+
+      if (query.format === 'csv') {
+        const csv = formatIncomeStatementCsv(report);
+        reply
+          .type('text/csv; charset=utf-8')
+          .header(
+            'Content-Disposition',
+            `attachment; filename="income-statement-${report.fiscalYear.label}.csv"`
+          )
+          .send(csv);
+        return;
+      }
+
+      const pdf = await formatIncomeStatementPdf(report);
+      reply
+        .type('application/pdf')
+        .header(
+          'Content-Disposition',
+          `attachment; filename="income-statement-${report.fiscalYear.label}.pdf"`
+        )
+        .send(Buffer.from(pdf));
+    }
+  );
+
+  fastify.get(
+    '/orgs/:orgId/reports/fec',
+    { preHandler: requireFecRole },
+    async (request, reply) => {
+      const { orgId } = organizationParamsSchema.parse(request.params);
+      const query = fecQuerySchema.parse(request.query);
+      ensureOrganizationAccess(request.user?.organizationId, orgId);
+
+      const report = await generateFecReport(request.prisma, orgId, query.fiscalYearId);
+
+      reply
+        .type('text/csv; charset=utf-8')
+        .header(
+          'Content-Disposition',
+          `attachment; filename="FEC_${orgId}_${report.fiscalYear.label}.csv"`
+        )
+        .header('x-report-checksum', report.checksum)
+        .send(report.csv);
+    }
+  );
+};
+
+function ensureOrganizationAccess(userOrgId: string | undefined, orgId: string): void {
+  if (!userOrgId) {
+    throw new HttpProblemError({
+      status: 401,
+      title: 'UNAUTHORIZED',
+      detail: 'Authentication is required.',
+    });
+  }
+
+  if (userOrgId !== orgId) {
+    throw new HttpProblemError({
+      status: 403,
+      title: 'FORBIDDEN_ORGANIZATION_ACCESS',
+      detail: 'You do not have access to this organization.',
+    });
+  }
+}
+
+function formatTrialBalanceCsv(report: TrialBalanceReport): string {
+  const header = 'Account Code;Account Name;Debit;Credit;Balance';
+  const lines = report.lines.map((line) =>
+    [
+      line.code,
+      line.name,
+      formatAmount(line.debit),
+      formatAmount(line.credit),
+      formatAmount(line.balance),
+    ].join(';')
+  );
+  lines.push(
+    ['TOTAL', '', formatAmount(report.totals.debit), formatAmount(report.totals.credit), formatAmount(report.totals.balance)].join(';')
+  );
+  return [header, ...lines].join('\n');
+}
+
+async function formatTrialBalancePdf(report: TrialBalanceReport): Promise<Uint8Array> {
+  const rows = report.lines.map((line) => [
+    line.code,
+    line.name,
+    formatAmount(line.debit),
+    formatAmount(line.credit),
+    formatAmount(line.balance),
+  ]);
+  rows.push([
+    'TOTAL',
+    '',
+    formatAmount(report.totals.debit),
+    formatAmount(report.totals.credit),
+    formatAmount(report.totals.balance),
+  ]);
+  return createTablePdf(`Trial Balance - ${report.fiscalYear.label}`, ['Code', 'Name', 'Debit', 'Credit', 'Balance'], rows);
+}
+
+function formatLedgerCsv(report: LedgerReport): string {
+  const header = 'Account Code;Account Name;Date;Journal;Reference;Memo;Debit;Credit;Balance';
+  const rows: string[] = [];
+  for (const account of report.accounts) {
+    for (const movement of account.movements) {
+      rows.push(
+        [
+          account.code,
+          account.name,
+          movement.date,
+          `${movement.journalCode} - ${movement.journalName}`,
+          movement.reference ?? '',
+          movement.memo ?? '',
+          formatAmount(movement.debit),
+          formatAmount(movement.credit),
+          formatAmount(movement.balance),
+        ].join(';')
+      );
+    }
+  }
+  return [header, ...rows].join('\n');
+}
+
+async function formatLedgerPdf(report: LedgerReport): Promise<Uint8Array> {
+  const rows: string[][] = [];
+  for (const account of report.accounts) {
+    rows.push([`${account.code} - ${account.name}`, '', '', '', '', '', '', '', '']);
+    for (const movement of account.movements) {
+      rows.push([
+        account.code,
+        movement.date,
+        `${movement.journalCode} - ${movement.journalName}`,
+        movement.reference ?? '',
+        movement.memo ?? '',
+        formatAmount(movement.debit),
+        formatAmount(movement.credit),
+        formatAmount(movement.balance),
+        '',
+      ]);
+    }
+  }
+  return createTablePdf(
+    `General Ledger - ${report.fiscalYear.label}`,
+    ['Account', 'Date', 'Journal', 'Reference', 'Memo', 'Debit', 'Credit', 'Balance', ''],
+    rows
+  );
+}
+
+function formatIncomeStatementCsv(report: IncomeStatementReport): string {
+  const header = 'Account Code;Account Name;Type;Debit;Credit;Balance;Result';
+  const rows = report.rows.map((row) =>
+    [
+      row.code,
+      row.name,
+      row.type,
+      formatAmount(row.debit),
+      formatAmount(row.credit),
+      formatAmount(row.balance),
+      formatAmount(row.result),
+    ].join(';')
+  );
+  rows.push(['TOTAL_REVENUE', '', '', '', '', '', formatAmount(report.totals.revenue)].join(';'));
+  rows.push(['TOTAL_EXPENSE', '', '', '', '', '', formatAmount(report.totals.expense)].join(';'));
+  rows.push(['NET_RESULT', '', '', '', '', '', formatAmount(report.totals.net)].join(';'));
+  return [header, ...rows].join('\n');
+}
+
+async function formatIncomeStatementPdf(report: IncomeStatementReport): Promise<Uint8Array> {
+  const rows = report.rows.map((row) => [
+    row.code,
+    row.name,
+    row.type,
+    formatAmount(row.debit),
+    formatAmount(row.credit),
+    formatAmount(row.balance),
+    formatAmount(row.result),
+  ]);
+  rows.push(['TOTAL_REVENUE', '', '', '', '', '', formatAmount(report.totals.revenue)]);
+  rows.push(['TOTAL_EXPENSE', '', '', '', '', '', formatAmount(report.totals.expense)]);
+  rows.push(['NET_RESULT', '', '', '', '', '', formatAmount(report.totals.net)]);
+  return createTablePdf(
+    `Income Statement - ${report.fiscalYear.label}`,
+    ['Code', 'Name', 'Type', 'Debit', 'Credit', 'Balance', 'Result'],
+    rows
+  );
+}
+
+async function createTablePdf(title: string, headers: string[], rows: string[][]): Promise<Uint8Array> {
+  const document = await PDFDocument.create();
+  const font = await document.embedFont(StandardFonts.Helvetica);
+  let page = document.addPage();
+  const margin = 40;
+  const lineHeight = 14;
+  let y = page.getHeight() - margin;
+
+  const drawText = (text: string, size = 12) => {
+    page.drawText(text, { x: margin, y, size, font });
+    y -= size + 4;
+  };
+
+  drawText(title, 16);
+  drawText(headers.join(' | '), 10);
+
+  for (const row of rows) {
+    if (y <= margin) {
+      page = document.addPage();
+      y = page.getHeight() - margin;
+      drawText(headers.join(' | '), 10);
+    }
+
+    drawText(row.join(' | '), 10);
+  }
+
+  return document.save();
+}
+
+function formatAmount(value: number): string {
+  return value.toFixed(2);
+}
+
+export default reportsRoutes;

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "fastify": "5.6.0",
         "fastify-plugin": "5.0.1",
         "jsonwebtoken": "9.0.2",
+        "pdf-lib": "1.17.1",
         "pino": "9.11.0",
         "redis": "5.8.2",
         "zod": "4.1.11"
@@ -44,6 +45,7 @@
         "@types/jsonwebtoken": "9.0.7",
         "@types/node": "24.5.2",
         "@types/pg": "8.11.6",
+        "@types/supertest": "2.0.16",
         "esbuild-register": "3.6.0",
         "pg": "8.13.1",
         "prisma": "6.16.2",
@@ -915,6 +917,24 @@
         "@noble/hashes": "^1.1.5"
       }
     },
+    "node_modules/@pdf-lib/standard-fonts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz",
+      "integrity": "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.6"
+      }
+    },
+    "node_modules/@pdf-lib/upng": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
+      "integrity": "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.10"
+      }
+    },
     "node_modules/@phc/format": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@phc/format/-/format-1.0.0.tgz",
@@ -1412,6 +1432,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1428,6 +1455,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "24.5.2",
@@ -1526,6 +1560,29 @@
       "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/superagent": {
+      "version": "8.1.9",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
+      "integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-2.0.16.tgz",
+      "integrity": "sha512-6c2ogktZ06tr2ENoZivgm7YnprnhYE4ZoXGMY+oA7IuAf17M8FWvujXZGmxLv8y0PTyts4x5A+erSwVUFA8XSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/superagent": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.44.0",
@@ -4775,6 +4832,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4840,6 +4903,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14.16"
+      }
+    },
+    "node_modules/pdf-lib": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
+      "integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@pdf-lib/standard-fonts": "^1.0.0",
+        "@pdf-lib/upng": "^1.0.1",
+        "pako": "^1.0.11",
+        "tslib": "^1.11.1"
       }
     },
     "node_modules/perfect-debounce": {
@@ -6127,6 +6202,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",


### PR DESCRIPTION
## Summary
- add reporting services to build journal, ledger, trial balance, income, and FEC data from Prisma
- expose `/reports` API endpoints that stream JSON/CSV/PDF formats and persist FEC exports with checksums
- cover the new flows with integration tests and a Prisma migration introducing the `fec_export` table

## Testing
- npm run build --workspace apps/api
- npm run test --workspace apps/api *(fails: PostgreSQL server unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d020a46c98832382b66578083328e3