### PR TITLE
feat(api): add bank accounts and statements support

### DIFF
--- a/apps/api/prisma/migrations/20250927090000_add_bank_treasury/migration.sql
+++ b/apps/api/prisma/migrations/20250927090000_add_bank_treasury/migration.sql
@@ -1,0 +1,76 @@
+BEGIN;
+
+CREATE TABLE "public"."bank_account" (
+    "id" UUID NOT NULL DEFAULT uuid_generate_v7(),
+    "organization_id" UUID NOT NULL,
+    "account_id" UUID NOT NULL,
+    "name" TEXT NOT NULL,
+    "iban" TEXT NOT NULL,
+    "bic" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "bank_account_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "bank_account_org_account_key" ON "public"."bank_account" ("organization_id", "account_id");
+CREATE UNIQUE INDEX "bank_account_account_id_key" ON "public"."bank_account" ("account_id");
+CREATE UNIQUE INDEX "bank_account_org_iban_key" ON "public"."bank_account" ("organization_id", "iban");
+CREATE INDEX "bank_account_org_idx" ON "public"."bank_account" ("organization_id");
+
+ALTER TABLE "public"."bank_account"
+  ADD CONSTRAINT "bank_account_organization_id_fkey"
+    FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "public"."bank_account"
+  ADD CONSTRAINT "bank_account_account_id_fkey"
+    FOREIGN KEY ("account_id") REFERENCES "public"."account"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+CREATE TABLE "public"."bank_statement" (
+    "id" UUID NOT NULL DEFAULT uuid_generate_v7(),
+    "organization_id" UUID NOT NULL,
+    "bank_account_id" UUID NOT NULL,
+    "statement_date" TIMESTAMP(3) NOT NULL,
+    "opening_balance" DECIMAL(16,2) NOT NULL,
+    "closing_balance" DECIMAL(16,2) NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "bank_statement_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "bank_statement_account_date_key" ON "public"."bank_statement" ("bank_account_id", "statement_date");
+CREATE INDEX "bank_statement_org_account_idx" ON "public"."bank_statement" ("organization_id", "bank_account_id");
+
+ALTER TABLE "public"."bank_statement"
+  ADD CONSTRAINT "bank_statement_organization_id_fkey"
+    FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "public"."bank_statement"
+  ADD CONSTRAINT "bank_statement_bank_account_id_fkey"
+    FOREIGN KEY ("bank_account_id") REFERENCES "public"."bank_account"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "public"."entry"
+  ADD COLUMN "bank_statement_id" UUID;
+
+CREATE INDEX "entry_org_bank_statement_idx" ON "public"."entry" ("organization_id", "bank_statement_id");
+
+ALTER TABLE "public"."entry"
+  ADD CONSTRAINT "entry_bank_statement_id_fkey"
+    FOREIGN KEY ("bank_statement_id") REFERENCES "public"."bank_statement"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "public"."bank_account" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."bank_account" FORCE ROW LEVEL SECURITY;
+CREATE POLICY "bank_account_isolation" ON "public"."bank_account"
+  FOR ALL
+  USING ("organization_id" = current_setting('app.current_org')::uuid)
+  WITH CHECK ("organization_id" = current_setting('app.current_org')::uuid);
+
+ALTER TABLE "public"."bank_statement" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."bank_statement" FORCE ROW LEVEL SECURITY;
+CREATE POLICY "bank_statement_isolation" ON "public"."bank_statement"
+  FOR ALL
+  USING ("organization_id" = current_setting('app.current_org')::uuid)
+  WITH CHECK ("organization_id" = current_setting('app.current_org')::uuid);
+
+COMMIT;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -22,6 +22,8 @@ model Organization {
   refreshTokens RefreshToken[]
   sequences   SequenceNumber[]
   fecExports  FecExport[]
+  bankAccounts BankAccount[]
+  bankStatements BankStatement[]
 
   @@map("organization")
 }
@@ -56,6 +58,7 @@ model Account {
   updatedAt      DateTime     @updatedAt @map("updated_at")
   organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Restrict)
   entryLines     EntryLine[]
+  bankAccount    BankAccount?
 
   @@unique([organizationId, code], map: "account_org_code_key")
   @@index([organizationId, type], map: "account_org_type_idx")
@@ -89,6 +92,7 @@ model Entry {
   memo           String?
   lockedAt       DateTime?    @map("locked_at")
   createdBy      String?      @map("created_by")
+  bankStatementId String?     @map("bank_statement_id") @db.Uuid
   createdAt      DateTime     @default(now()) @map("created_at")
   updatedAt      DateTime     @updatedAt @map("updated_at")
   organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Restrict)
@@ -96,11 +100,50 @@ model Entry {
   journal        Journal      @relation(fields: [journalId], references: [id], onDelete: Restrict)
   lines          EntryLine[]
   attachments    Attachment[]
+  bankStatement  BankStatement? @relation(fields: [bankStatementId], references: [id], onDelete: SetNull)
 
   @@index([organizationId, date], map: "entry_org_date_idx")
   @@index([organizationId, fiscalYearId], map: "entry_org_fiscal_year_idx")
   @@index([organizationId, journalId, date], map: "entry_org_journal_date_idx")
+  @@index([organizationId, bankStatementId], map: "entry_org_bank_statement_idx")
   @@map("entry")
+}
+
+model BankAccount {
+  id             String       @id @default(dbgenerated("uuid_generate_v7()")) @db.Uuid
+  organizationId String       @map("organization_id") @db.Uuid
+  accountId      String       @map("account_id") @db.Uuid @unique
+  name           String
+  iban           String
+  bic            String?
+  createdAt      DateTime     @default(now()) @map("created_at")
+  updatedAt      DateTime     @updatedAt @map("updated_at")
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Restrict)
+  account        Account      @relation(fields: [accountId], references: [id], onDelete: Restrict)
+  statements     BankStatement[]
+
+  @@unique([organizationId, accountId], map: "bank_account_org_account_key")
+  @@unique([organizationId, iban], map: "bank_account_org_iban_key")
+  @@index([organizationId], map: "bank_account_org_idx")
+  @@map("bank_account")
+}
+
+model BankStatement {
+  id             String        @id @default(dbgenerated("uuid_generate_v7()")) @db.Uuid
+  organizationId String        @map("organization_id") @db.Uuid
+  bankAccountId  String        @map("bank_account_id") @db.Uuid
+  statementDate  DateTime      @map("statement_date")
+  openingBalance Decimal       @map("opening_balance") @db.Decimal(16, 2)
+  closingBalance Decimal       @map("closing_balance") @db.Decimal(16, 2)
+  createdAt      DateTime      @default(now()) @map("created_at")
+  updatedAt      DateTime      @updatedAt @map("updated_at")
+  organization   Organization  @relation(fields: [organizationId], references: [id], onDelete: Restrict)
+  bankAccount    BankAccount   @relation(fields: [bankAccountId], references: [id], onDelete: Restrict)
+  entries        Entry[]
+
+  @@unique([bankAccountId, statementDate], map: "bank_statement_account_date_key")
+  @@index([organizationId, bankAccountId], map: "bank_statement_org_account_idx")
+  @@map("bank_statement")
 }
 
 model SequenceNumber {

--- a/apps/api/src/__tests__/bank.http.test.ts
+++ b/apps/api/src/__tests__/bank.http.test.ts
@@ -1,0 +1,329 @@
+import type { FastifyInstance } from 'fastify';
+import request from 'supertest';
+import { beforeAll, afterAll, beforeEach, describe, expect, it } from 'vitest';
+import { PrismaClient, UserRole } from '@prisma/client';
+import buildServer from '../server';
+import {
+  setupTestDatabase,
+  teardownTestDatabase,
+  resetDatabase,
+  createPrismaClient,
+  applyTenantContext,
+} from './helpers/database';
+
+const TEST_ACCESS_SECRET = 'test-access-secret-change-me-12345678901234567890';
+const TEST_REFRESH_SECRET = 'test-refresh-secret-change-me-12345678901234567890';
+const VALID_IBAN = 'DE89370400440532013000';
+
+let app: FastifyInstance;
+let prisma: PrismaClient;
+
+beforeAll(async () => {
+  process.env.JWT_ACCESS_SECRET = TEST_ACCESS_SECRET;
+  process.env.JWT_REFRESH_SECRET = TEST_REFRESH_SECRET;
+  process.env.REFRESH_TOKEN_TTL_DAYS = '30';
+  process.env.NODE_ENV = 'test';
+
+  await setupTestDatabase();
+
+  prisma = createPrismaClient();
+  await prisma.$connect();
+
+  app = await buildServer();
+  await app.ready();
+});
+
+afterAll(async () => {
+  await app.close();
+  await prisma.$disconnect();
+  await teardownTestDatabase();
+});
+
+beforeEach(async () => {
+  await resetDatabase();
+});
+
+describe('bank routes', () => {
+  it('manages bank accounts with validations', async () => {
+    const { organizationId, accessToken } = await createUserWithRole(UserRole.TREASURER);
+
+    const ledgerAccount = await prisma.$transaction(async (tx) => {
+      await applyTenantContext(tx, organizationId);
+      return tx.account.create({
+        data: {
+          organizationId,
+          code: '512100',
+          name: 'Banque principale',
+          type: 'ASSET',
+        },
+      });
+    });
+
+    const createResponse = await request(app.server)
+      .post(`/api/v1/orgs/${organizationId}/bank/accounts`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({
+        accountId: ledgerAccount.id,
+        name: 'Compte courant',
+        iban: 'de89 3704 0044 0532 0130 00',
+        bic: 'deutdeff',
+      });
+
+    expect(createResponse.statusCode).toBe(201);
+    expect(createResponse.body.data.name).toBe('Compte courant');
+    expect(createResponse.body.data.iban).toBe(VALID_IBAN);
+    expect(createResponse.body.data.bic).toBe('DEUTDEFF');
+
+    const listResponse = await request(app.server)
+      .get(`/api/v1/orgs/${organizationId}/bank/accounts`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(listResponse.statusCode).toBe(200);
+    expect(listResponse.body.data).toHaveLength(1);
+
+    const accountId = createResponse.body.data.id as string;
+
+    const getResponse = await request(app.server)
+      .get(`/api/v1/orgs/${organizationId}/bank/accounts/${accountId}`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(getResponse.statusCode).toBe(200);
+    expect(getResponse.body.data.iban).toBe(VALID_IBAN);
+
+    const updateResponse = await request(app.server)
+      .patch(`/api/v1/orgs/${organizationId}/bank/accounts/${accountId}`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({
+        name: 'Compte Banque',
+        bic: 'DEUTDEFF500',
+      });
+
+    expect(updateResponse.statusCode).toBe(200);
+    expect(updateResponse.body.data.name).toBe('Compte Banque');
+    expect(updateResponse.body.data.bic).toBe('DEUTDEFF500');
+
+    const deleteResponse = await request(app.server)
+      .delete(`/api/v1/orgs/${organizationId}/bank/accounts/${accountId}`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(deleteResponse.statusCode).toBe(204);
+
+    const afterDelete = await request(app.server)
+      .get(`/api/v1/orgs/${organizationId}/bank/accounts`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(afterDelete.statusCode).toBe(200);
+    expect(afterDelete.body.data).toHaveLength(0);
+  });
+
+  it('records bank statements and links entries', async () => {
+    const { organizationId, accessToken } = await createUserWithRole(UserRole.TREASURER);
+    const fixtures = await seedBankingFixtures(organizationId);
+
+    const bankAccountResponse = await request(app.server)
+      .post(`/api/v1/orgs/${organizationId}/bank/accounts`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({
+        accountId: fixtures.bankLedgerAccount.id,
+        name: 'Compte Banque',
+        iban: VALID_IBAN,
+        bic: 'AGRIFRPP',
+      });
+
+    const bankAccountId = bankAccountResponse.body.data.id as string;
+
+    const depositResponse = await request(app.server)
+      .post(`/api/v1/orgs/${organizationId}/entries`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({
+        fiscalYearId: fixtures.fiscalYear.id,
+        journalId: fixtures.journal.id,
+        date: '2025-01-15',
+        memo: 'Cotisations',
+        lines: [
+          { accountId: fixtures.bankLedgerAccount.id, debit: '200.00' },
+          { accountId: fixtures.revenueAccount.id, credit: '200.00' },
+        ],
+      });
+
+    const withdrawalResponse = await request(app.server)
+      .post(`/api/v1/orgs/${organizationId}/entries`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({
+        fiscalYearId: fixtures.fiscalYear.id,
+        journalId: fixtures.journal.id,
+        date: '2025-01-20',
+        memo: 'Frais bancaires',
+        lines: [
+          { accountId: fixtures.expenseAccount.id, debit: '70.00' },
+          { accountId: fixtures.bankLedgerAccount.id, credit: '70.00' },
+        ],
+      });
+
+    const entryIds = [depositResponse.body.data.id as string, withdrawalResponse.body.data.id as string];
+
+    const statementResponse = await request(app.server)
+      .post(`/api/v1/orgs/${organizationId}/bank/statements`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({
+        bankAccountId,
+        statementDate: '2025-01-31',
+        openingBalance: '1000.00',
+        closingBalance: '1130.00',
+        entryIds,
+      });
+
+    expect(statementResponse.statusCode).toBe(201);
+    expect(statementResponse.body.data.openingBalance).toBe('1000.00');
+    expect(statementResponse.body.data.closingBalance).toBe('1130.00');
+    expect(statementResponse.body.data.entries).toHaveLength(2);
+
+    const statementId = statementResponse.body.data.id as string;
+
+    const entries = await prisma.$transaction(async (tx) => {
+      await applyTenantContext(tx, organizationId);
+      return tx.entry.findMany({
+        where: { id: { in: entryIds } },
+        select: { id: true, bankStatementId: true },
+        orderBy: { date: 'asc' },
+      });
+    });
+
+    expect(entries.every((entry) => entry.bankStatementId === statementId)).toBe(true);
+  });
+
+  it('rejects incoherent bank statement balances', async () => {
+    const { organizationId, accessToken } = await createUserWithRole(UserRole.TREASURER);
+    const fixtures = await seedBankingFixtures(organizationId);
+
+    const bankAccountResponse = await request(app.server)
+      .post(`/api/v1/orgs/${organizationId}/bank/accounts`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({
+        accountId: fixtures.bankLedgerAccount.id,
+        name: 'Compte Banque',
+        iban: VALID_IBAN,
+        bic: 'AGRIFRPP',
+      });
+
+    const bankAccountId = bankAccountResponse.body.data.id as string;
+
+    const depositResponse = await request(app.server)
+      .post(`/api/v1/orgs/${organizationId}/entries`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({
+        fiscalYearId: fixtures.fiscalYear.id,
+        journalId: fixtures.journal.id,
+        date: '2025-02-05',
+        lines: [
+          { accountId: fixtures.bankLedgerAccount.id, debit: '50.00' },
+          { accountId: fixtures.revenueAccount.id, credit: '50.00' },
+        ],
+      });
+
+    const entryId = depositResponse.body.data.id as string;
+
+    const statementResponse = await request(app.server)
+      .post(`/api/v1/orgs/${organizationId}/bank/statements`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({
+        bankAccountId,
+        statementDate: '2025-02-28',
+        openingBalance: '1000.00',
+        closingBalance: '1200.00',
+        entryIds: [entryId],
+      });
+
+    expect(statementResponse.statusCode).toBe(422);
+    expect(statementResponse.body.title).toBe('BANK_STATEMENT_BALANCE_MISMATCH');
+
+    const entry = await prisma.$transaction(async (tx) => {
+      await applyTenantContext(tx, organizationId);
+      return tx.entry.findUnique({
+        where: { id: entryId },
+        select: { bankStatementId: true },
+      });
+    });
+
+    expect(entry?.bankStatementId).toBeNull();
+  });
+});
+
+async function createUserWithRole(role: UserRole) {
+  const organization = await prisma.organization.create({ data: { name: `Org ${Date.now()}` } });
+  const user = await prisma.user.create({
+    data: {
+      email: `user+${Math.random().toString(16).slice(2)}@example.org`,
+      passwordHash: 'test-hash',
+    },
+  });
+
+  await prisma.userOrgRole.create({
+    data: {
+      organizationId: organization.id,
+      userId: user.id,
+      role,
+    },
+  });
+
+  const accessToken = app.issueAccessToken({
+    userId: user.id,
+    organizationId: organization.id,
+    roles: [role],
+  });
+
+  return { organizationId: organization.id, accessToken, userId: user.id };
+}
+
+async function seedBankingFixtures(organizationId: string) {
+  return prisma.$transaction(async (tx) => {
+    await applyTenantContext(tx, organizationId);
+
+    const fiscalYear = await tx.fiscalYear.create({
+      data: {
+        organizationId,
+        label: 'FY2025',
+        startDate: new Date('2025-01-01'),
+        endDate: new Date('2025-12-31'),
+      },
+    });
+
+    const journal = await tx.journal.create({
+      data: {
+        organizationId,
+        code: 'BAN',
+        name: 'Journal Banque',
+        type: 'BANK',
+      },
+    });
+
+    const bankLedgerAccount = await tx.account.create({
+      data: {
+        organizationId,
+        code: '512200',
+        name: 'Banque Courante',
+        type: 'ASSET',
+      },
+    });
+
+    const revenueAccount = await tx.account.create({
+      data: {
+        organizationId,
+        code: '706100',
+        name: 'Cotisations',
+        type: 'REVENUE',
+      },
+    });
+
+    const expenseAccount = await tx.account.create({
+      data: {
+        organizationId,
+        code: '627100',
+        name: 'Frais bancaires',
+        type: 'EXPENSE',
+      },
+    });
+
+    return { fiscalYear, journal, bankLedgerAccount, revenueAccount, expenseAccount };
+  });
+}

--- a/apps/api/src/__tests__/helpers/database.ts
+++ b/apps/api/src/__tests__/helpers/database.ts
@@ -57,7 +57,7 @@ export async function resetDatabase(): Promise<void> {
   const adminClient = new PgClient({ connectionString: buildAdminDatabaseUrl(currentDatabaseName) });
   await adminClient.connect();
   await adminClient.query(
-    'TRUNCATE TABLE "refresh_token", "user_org_role", "user", "attachment", "fec_export", "entry_line", "entry", "sequence_number", "journal", "account", "fiscal_year", "organization" RESTART IDENTITY CASCADE'
+    'TRUNCATE TABLE "refresh_token", "user_org_role", "user", "attachment", "fec_export", "entry_line", "entry", "bank_statement", "bank_account", "sequence_number", "journal", "account", "fiscal_year", "organization" RESTART IDENTITY CASCADE'
   );
   await adminClient.end();
 }

--- a/apps/api/src/modules/accounting/bank-accounts/index.ts
+++ b/apps/api/src/modules/accounting/bank-accounts/index.ts
@@ -1,0 +1,2 @@
+export * from './schemas';
+export * from './service';

--- a/apps/api/src/modules/accounting/bank-accounts/schemas.ts
+++ b/apps/api/src/modules/accounting/bank-accounts/schemas.ts
@@ -1,0 +1,112 @@
+import { z } from 'zod';
+
+const ibanPattern = /^[0-9A-Z]+$/;
+const bicPattern = /^[A-Z]{4}[A-Z]{2}[A-Z0-9]{2}([A-Z0-9]{3})?$/;
+
+export function normalizeIban(input: string): string {
+  return input.replace(/\s+/g, '').toUpperCase();
+}
+
+export function isValidIban(input: string): boolean {
+  const iban = normalizeIban(input);
+
+  if (iban.length < 15 || iban.length > 34) {
+    return false;
+  }
+
+  if (!ibanPattern.test(iban)) {
+    return false;
+  }
+
+  const rearranged = iban.slice(4) + iban.slice(0, 4);
+  let numeric = '';
+
+  for (const char of rearranged) {
+    const code = char.charCodeAt(0);
+    if (code >= 65 && code <= 90) {
+      numeric += String(code - 55);
+    } else if (code >= 48 && code <= 57) {
+      numeric += char;
+    } else {
+      return false;
+    }
+  }
+
+  let remainder = 0;
+  for (const digit of numeric) {
+    remainder = (remainder * 10 + Number(digit)) % 97;
+  }
+
+  return remainder === 1;
+}
+
+export function isValidBic(input: string): boolean {
+  return bicPattern.test(input);
+}
+
+const nameSchema = z
+  .string()
+  .trim()
+  .min(1, { message: 'Name is required.' })
+  .max(255, { message: 'Name must be at most 255 characters long.' });
+
+const ibanSchema = z
+  .string()
+  .trim()
+  .min(1, { message: 'IBAN is required.' })
+  .transform((value) => normalizeIban(value))
+  .superRefine((value, ctx) => {
+    if (!isValidIban(value)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'IBAN is invalid.',
+      });
+    }
+  });
+
+const bicSchema = z
+  .string()
+  .trim()
+  .min(8, { message: 'BIC must be 8 or 11 characters long.' })
+  .max(11, { message: 'BIC must be 8 or 11 characters long.' })
+  .transform((value) => value.toUpperCase())
+  .superRefine((value, ctx) => {
+    if (!isValidBic(value)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'BIC is invalid.',
+      });
+    }
+  });
+
+const optionalBicSchema = z
+  .union([bicSchema, z.null()])
+  .optional()
+  .transform((value) => {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    return value === null ? null : value;
+  });
+
+export const createBankAccountInputSchema = z.object({
+  accountId: z.string().uuid(),
+  name: nameSchema,
+  iban: ibanSchema,
+  bic: bicSchema.optional(),
+});
+
+export const updateBankAccountInputSchema = z
+  .object({
+    accountId: z.string().uuid().optional(),
+    name: nameSchema.optional(),
+    iban: ibanSchema.optional(),
+    bic: optionalBicSchema,
+  })
+  .refine((value) => Object.keys(value).length > 0, {
+    message: 'At least one field must be provided to update the bank account.',
+  });
+
+export type CreateBankAccountInput = z.infer<typeof createBankAccountInputSchema>;
+export type UpdateBankAccountInput = z.infer<typeof updateBankAccountInputSchema>;

--- a/apps/api/src/modules/accounting/bank-accounts/service.ts
+++ b/apps/api/src/modules/accounting/bank-accounts/service.ts
@@ -1,0 +1,244 @@
+import type { Prisma, PrismaClient } from '@prisma/client';
+import { Prisma as PrismaNamespace } from '@prisma/client';
+import { z } from 'zod';
+import { HttpProblemError } from '../../../lib/problem-details';
+import { createBankAccountInputSchema, updateBankAccountInputSchema } from './schemas';
+
+export type BankAccountClient = PrismaClient | Prisma.TransactionClient;
+
+export async function listBankAccounts(client: BankAccountClient, organizationId: string) {
+  return client.bankAccount.findMany({
+    where: { organizationId },
+    orderBy: [{ name: 'asc' }, { createdAt: 'asc' }],
+  });
+}
+
+export async function getBankAccount(
+  client: BankAccountClient,
+  organizationId: string,
+  bankAccountId: string
+) {
+  const account = await client.bankAccount.findFirst({
+    where: { id: bankAccountId, organizationId },
+  });
+
+  if (!account) {
+    throw bankAccountNotFound();
+  }
+
+  return account;
+}
+
+export async function createBankAccount(
+  client: BankAccountClient,
+  organizationId: string,
+  input: unknown
+) {
+  const parsed = parseInput(createBankAccountInputSchema, input, 'Invalid bank account payload.');
+
+  await ensureAccountBelongsToOrganization(client, organizationId, parsed.accountId);
+  await ensureAccountAvailable(client, organizationId, parsed.accountId);
+  await ensureIbanAvailable(client, organizationId, parsed.iban);
+
+  try {
+    return await client.bankAccount.create({
+      data: {
+        organizationId,
+        accountId: parsed.accountId,
+        name: parsed.name,
+        iban: parsed.iban,
+        bic: parsed.bic ?? null,
+      },
+    });
+  } catch (error) {
+    handleKnownPrismaErrors(error);
+    throw error;
+  }
+}
+
+export async function updateBankAccount(
+  client: BankAccountClient,
+  organizationId: string,
+  bankAccountId: string,
+  input: unknown
+) {
+  const parsed = parseInput(updateBankAccountInputSchema, input, 'Invalid bank account update payload.');
+
+  const existing = await client.bankAccount.findFirst({
+    where: { id: bankAccountId, organizationId },
+  });
+
+  if (!existing) {
+    throw bankAccountNotFound();
+  }
+
+  if (parsed.accountId && parsed.accountId !== existing.accountId) {
+    await ensureAccountBelongsToOrganization(client, organizationId, parsed.accountId);
+    await ensureAccountAvailable(client, organizationId, parsed.accountId);
+  }
+
+  if (parsed.iban && parsed.iban !== existing.iban) {
+    await ensureIbanAvailable(client, organizationId, parsed.iban);
+  }
+
+  const data: Prisma.BankAccountUpdateInput = {};
+
+  if (parsed.accountId !== undefined) {
+    data.account = { connect: { id: parsed.accountId } };
+  }
+  if (parsed.name !== undefined) {
+    data.name = parsed.name;
+  }
+  if (parsed.iban !== undefined) {
+    data.iban = parsed.iban;
+  }
+  if (parsed.bic !== undefined) {
+    data.bic = parsed.bic;
+  }
+
+  try {
+    return await client.bankAccount.update({
+      where: { id: existing.id },
+      data,
+    });
+  } catch (error) {
+    handleKnownPrismaErrors(error);
+    throw error;
+  }
+}
+
+export async function deleteBankAccount(
+  client: BankAccountClient,
+  organizationId: string,
+  bankAccountId: string
+): Promise<void> {
+  const existing = await client.bankAccount.findFirst({
+    where: { id: bankAccountId, organizationId },
+    select: { id: true },
+  });
+
+  if (!existing) {
+    throw bankAccountNotFound();
+  }
+
+  const statementCount = await client.bankStatement.count({
+    where: { organizationId, bankAccountId },
+  });
+
+  if (statementCount > 0) {
+    throw new HttpProblemError({
+      status: 409,
+      title: 'BANK_ACCOUNT_HAS_STATEMENTS',
+      detail: 'The bank account cannot be deleted while statements are linked to it.',
+    });
+  }
+
+  await client.bankAccount.delete({
+    where: { id: existing.id },
+  });
+}
+
+async function ensureAccountBelongsToOrganization(
+  client: BankAccountClient,
+  organizationId: string,
+  accountId: string
+): Promise<void> {
+  const account = await client.account.findFirst({
+    where: { id: accountId, organizationId },
+    select: { id: true },
+  });
+
+  if (!account) {
+    throw new HttpProblemError({
+      status: 404,
+      title: 'ACCOUNT_NOT_FOUND',
+      detail: 'The specified general ledger account does not exist in this organization.',
+    });
+  }
+}
+
+async function ensureAccountAvailable(
+  client: BankAccountClient,
+  organizationId: string,
+  accountId: string
+): Promise<void> {
+  const existing = await client.bankAccount.findFirst({
+    where: { organizationId, accountId },
+    select: { id: true },
+  });
+
+  if (existing) {
+    throw new HttpProblemError({
+      status: 409,
+      title: 'BANK_ACCOUNT_ACCOUNT_ALREADY_LINKED',
+      detail: 'This general ledger account is already linked to a bank account.',
+    });
+  }
+}
+
+async function ensureIbanAvailable(
+  client: BankAccountClient,
+  organizationId: string,
+  iban: string
+): Promise<void> {
+  const existing = await client.bankAccount.findFirst({
+    where: { organizationId, iban },
+    select: { id: true },
+  });
+
+  if (existing) {
+    throw new HttpProblemError({
+      status: 409,
+      title: 'BANK_ACCOUNT_IBAN_ALREADY_EXISTS',
+      detail: 'A bank account with this IBAN already exists for the organization.',
+    });
+  }
+}
+
+function handleKnownPrismaErrors(error: unknown): void {
+  if (!(error instanceof PrismaNamespace.PrismaClientKnownRequestError)) {
+    return;
+  }
+
+  if (error.code === 'P2002') {
+    const target = Array.isArray(error.meta?.target) ? error.meta?.target.join(',') : String(error.meta?.target ?? '');
+
+    if (target.includes('bank_account_org_account_key')) {
+      throw new HttpProblemError({
+        status: 409,
+        title: 'BANK_ACCOUNT_ACCOUNT_ALREADY_LINKED',
+        detail: 'This general ledger account is already linked to a bank account.',
+      });
+    }
+
+    if (target.includes('bank_account_org_iban_key')) {
+      throw new HttpProblemError({
+        status: 409,
+        title: 'BANK_ACCOUNT_IBAN_ALREADY_EXISTS',
+        detail: 'A bank account with this IBAN already exists for the organization.',
+      });
+    }
+  }
+}
+
+function bankAccountNotFound(): HttpProblemError {
+  return new HttpProblemError({
+    status: 404,
+    title: 'BANK_ACCOUNT_NOT_FOUND',
+    detail: 'The requested bank account does not exist for this organization.',
+  });
+}
+
+function parseInput<T extends z.ZodTypeAny>(schema: T, input: unknown, detail: string): z.infer<T> {
+  const result = schema.safeParse(input);
+  if (!result.success) {
+    throw new HttpProblemError({
+      status: 400,
+      title: 'VALIDATION_ERROR',
+      detail,
+      cause: result.error,
+    });
+  }
+
+  return result.data;
+}

--- a/apps/api/src/modules/accounting/bank-statements/index.ts
+++ b/apps/api/src/modules/accounting/bank-statements/index.ts
@@ -1,0 +1,2 @@
+export * from './schemas';
+export * from './service';

--- a/apps/api/src/modules/accounting/bank-statements/schemas.ts
+++ b/apps/api/src/modules/accounting/bank-statements/schemas.ts
@@ -1,0 +1,55 @@
+import { Prisma } from '@prisma/client';
+import { z } from 'zod';
+
+const decimalPattern = /^-?\d+(\.\d{1,2})?$/;
+
+const decimalSchema = z
+  .union([z.string(), z.number()])
+  .transform((value, ctx) => {
+    const raw = typeof value === 'number' ? value.toString() : value;
+    const normalized = raw.trim();
+
+    if (normalized === '') {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Amount is required.',
+      });
+      return z.NEVER;
+    }
+
+    if (!decimalPattern.test(normalized)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Amount must have at most two decimal places.',
+      });
+      return z.NEVER;
+    }
+
+    try {
+      return new Prisma.Decimal(normalized);
+    } catch {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Amount is invalid.',
+      });
+      return z.NEVER;
+    }
+  })
+  .superRefine((value, ctx) => {
+    if (value.decimalPlaces() > 2) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Amount must have at most two decimal places.',
+      });
+    }
+  });
+
+export const recordBankStatementInputSchema = z.object({
+  bankAccountId: z.string().uuid(),
+  statementDate: z.coerce.date(),
+  openingBalance: decimalSchema,
+  closingBalance: decimalSchema,
+  entryIds: z.array(z.string().uuid()).default([]),
+});
+
+export type RecordBankStatementInput = z.infer<typeof recordBankStatementInputSchema>;

--- a/apps/api/src/modules/accounting/bank-statements/service.ts
+++ b/apps/api/src/modules/accounting/bank-statements/service.ts
@@ -1,0 +1,143 @@
+import type { PrismaClient } from '@prisma/client';
+import { Prisma as PrismaNamespace } from '@prisma/client';
+import { z } from 'zod';
+import { HttpProblemError } from '../../../lib/problem-details';
+import { recordBankStatementInputSchema } from './schemas';
+
+export type BankStatementClient = PrismaClient | PrismaNamespace.TransactionClient;
+
+export async function recordBankStatement(
+  client: BankStatementClient,
+  organizationId: string,
+  input: unknown
+) {
+  const parsed = parseInput(
+    recordBankStatementInputSchema,
+    input,
+    'Invalid bank statement payload.'
+  );
+
+  const bankAccount = await client.bankAccount.findFirst({
+    where: { id: parsed.bankAccountId, organizationId },
+    select: { id: true, accountId: true },
+  });
+
+  if (!bankAccount) {
+    throw new HttpProblemError({
+      status: 404,
+      title: 'BANK_ACCOUNT_NOT_FOUND',
+      detail: 'The specified bank account does not exist for this organization.',
+    });
+  }
+
+  const uniqueEntryIds = Array.from(new Set(parsed.entryIds));
+
+  const zero = new PrismaNamespace.Decimal(0);
+  let entries: Array<{
+    id: string;
+    bankStatementId: string | null;
+    lines: { debit: PrismaNamespace.Decimal; credit: PrismaNamespace.Decimal }[];
+  }> = [];
+
+  if (uniqueEntryIds.length > 0) {
+    entries = await client.entry.findMany({
+      where: {
+        organizationId,
+        id: { in: uniqueEntryIds },
+      },
+      select: {
+        id: true,
+        bankStatementId: true,
+        lines: {
+          where: { accountId: bankAccount.accountId },
+          select: { debit: true, credit: true },
+        },
+      },
+    });
+
+    if (entries.length !== uniqueEntryIds.length) {
+      throw new HttpProblemError({
+        status: 404,
+        title: 'ENTRY_NOT_FOUND',
+        detail: 'One or more entries were not found in the organization.',
+      });
+    }
+
+    for (const entry of entries) {
+      if (entry.bankStatementId) {
+        throw new HttpProblemError({
+          status: 409,
+          title: 'ENTRY_ALREADY_LINKED_TO_STATEMENT',
+          detail: 'An entry is already linked to a bank statement.',
+        });
+      }
+
+      if (entry.lines.length === 0) {
+        throw new HttpProblemError({
+          status: 422,
+          title: 'ENTRY_MISSING_BANK_LINE',
+          detail: 'All entries must contain at least one line for the bank account.',
+        });
+      }
+    }
+  }
+
+  const netChange = entries.reduce((sum, entry) => {
+    const entryChange = entry.lines.reduce(
+      (lineSum, line) => lineSum.add(line.debit).sub(line.credit),
+      zero
+    );
+    return sum.add(entryChange);
+  }, zero);
+
+  const expectedClosing = parsed.openingBalance.add(netChange);
+
+  if (!expectedClosing.equals(parsed.closingBalance)) {
+    throw new HttpProblemError({
+      status: 422,
+      title: 'BANK_STATEMENT_BALANCE_MISMATCH',
+      detail: 'Closing balance does not match the opening balance and linked entries.',
+    });
+  }
+
+  const statement = await client.bankStatement.create({
+    data: {
+      organizationId,
+      bankAccountId: parsed.bankAccountId,
+      statementDate: parsed.statementDate,
+      openingBalance: parsed.openingBalance,
+      closingBalance: parsed.closingBalance,
+    },
+  });
+
+  if (uniqueEntryIds.length > 0) {
+    await client.entry.updateMany({
+      where: { organizationId, id: { in: uniqueEntryIds } },
+      data: { bankStatementId: statement.id },
+    });
+  }
+
+  return client.bankStatement.findUnique({
+    where: { id: statement.id },
+    include: {
+      entries: {
+        select: { id: true, reference: true, date: true },
+        orderBy: { date: 'asc' },
+      },
+    },
+  });
+}
+
+function parseInput<T extends z.ZodTypeAny>(schema: T, input: unknown, detail: string): z.infer<T> {
+  const result = schema.safeParse(input);
+  if (!result.success) {
+    throw new HttpProblemError({
+      status: 400,
+      title: 'VALIDATION_ERROR',
+      detail,
+      cause: result.error,
+    });
+  }
+
+  return result.data;
+}

--- a/apps/api/src/modules/accounting/entries/schemas.ts
+++ b/apps/api/src/modules/accounting/entries/schemas.ts
@@ -27,7 +27,7 @@ const amountSchema = z
 
     try {
       return new Prisma.Decimal(normalized);
-    } catch (error) {
+    } catch {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: 'Amount is invalid.',

--- a/apps/api/src/routes/bank.ts
+++ b/apps/api/src/routes/bank.ts
@@ -1,0 +1,116 @@
+import type { FastifyPluginAsync } from 'fastify';
+import { z } from 'zod';
+import { UserRole } from '@prisma/client';
+import { HttpProblemError } from '../lib/problem-details';
+import {
+  createBankAccount,
+  deleteBankAccount,
+  getBankAccount,
+  listBankAccounts,
+  updateBankAccount,
+} from '../modules/accounting/bank-accounts';
+import { recordBankStatement } from '../modules/accounting/bank-statements';
+
+const organizationParamsSchema = z.object({
+  orgId: z.string().uuid(),
+});
+
+const bankAccountParamsSchema = organizationParamsSchema.extend({
+  bankAccountId: z.string().uuid(),
+});
+
+const bankRoutes: FastifyPluginAsync = async (fastify) => {
+  const requireTreasuryRole = fastify.authorizeRoles(UserRole.TREASURER, UserRole.ADMIN);
+
+  fastify.get(
+    '/orgs/:orgId/bank/accounts',
+    { preHandler: requireTreasuryRole },
+    async (request) => {
+      const { orgId } = organizationParamsSchema.parse(request.params);
+      ensureOrganizationAccess(request.user?.organizationId, orgId);
+
+      const accounts = await listBankAccounts(request.prisma, orgId);
+      return { data: accounts };
+    }
+  );
+
+  fastify.post(
+    '/orgs/:orgId/bank/accounts',
+    { preHandler: requireTreasuryRole },
+    async (request, reply) => {
+      const { orgId } = organizationParamsSchema.parse(request.params);
+      ensureOrganizationAccess(request.user?.organizationId, orgId);
+
+      const account = await createBankAccount(request.prisma, orgId, request.body);
+      reply.status(201).send({ data: account });
+    }
+  );
+
+  fastify.get(
+    '/orgs/:orgId/bank/accounts/:bankAccountId',
+    { preHandler: requireTreasuryRole },
+    async (request) => {
+      const { orgId, bankAccountId } = bankAccountParamsSchema.parse(request.params);
+      ensureOrganizationAccess(request.user?.organizationId, orgId);
+
+      const account = await getBankAccount(request.prisma, orgId, bankAccountId);
+      return { data: account };
+    }
+  );
+
+  fastify.patch(
+    '/orgs/:orgId/bank/accounts/:bankAccountId',
+    { preHandler: requireTreasuryRole },
+    async (request) => {
+      const { orgId, bankAccountId } = bankAccountParamsSchema.parse(request.params);
+      ensureOrganizationAccess(request.user?.organizationId, orgId);
+
+      const account = await updateBankAccount(request.prisma, orgId, bankAccountId, request.body);
+      return { data: account };
+    }
+  );
+
+  fastify.delete(
+    '/orgs/:orgId/bank/accounts/:bankAccountId',
+    { preHandler: requireTreasuryRole },
+    async (request, reply) => {
+      const { orgId, bankAccountId } = bankAccountParamsSchema.parse(request.params);
+      ensureOrganizationAccess(request.user?.organizationId, orgId);
+
+      await deleteBankAccount(request.prisma, orgId, bankAccountId);
+      reply.status(204).send();
+    }
+  );
+
+  fastify.post(
+    '/orgs/:orgId/bank/statements',
+    { preHandler: requireTreasuryRole },
+    async (request, reply) => {
+      const { orgId } = organizationParamsSchema.parse(request.params);
+      ensureOrganizationAccess(request.user?.organizationId, orgId);
+
+      const statement = await recordBankStatement(request.prisma, orgId, request.body);
+      reply.status(201).send({ data: statement });
+    }
+  );
+};
+
+function ensureOrganizationAccess(userOrgId: string | undefined, orgId: string): void {
+  if (!userOrgId) {
+    throw new HttpProblemError({
+      status: 401,
+      title: 'UNAUTHORIZED',
+      detail: 'Authentication is required.',
+    });
+  }
+
+  if (userOrgId !== orgId) {
+    throw new HttpProblemError({
+      status: 403,
+      title: 'FORBIDDEN_ORGANIZATION_ACCESS',
+      detail: 'You do not have access to this organization.',
+    });
+  }
+}
+
+export default bankRoutes;

--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -313,7 +313,6 @@ async function createTablePdf(title: string, headers: string[], rows: string[][]
   const font = await document.embedFont(StandardFonts.Helvetica);
   let page = document.addPage();
   const margin = 40;
-  const lineHeight = 14;
   let y = page.getHeight() - margin;
 
   const drawText = (text: string, size = 12) => {

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -19,7 +19,7 @@ if (process.env.NODE_ENV !== 'production') {
   if (!process.env.FASTIFY_AUTOLOAD_TYPESCRIPT) {
     process.env.FASTIFY_AUTOLOAD_TYPESCRIPT = '1';
   }
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
   require('esbuild-register');
 }
 


### PR DESCRIPTION
## Summary
- add Prisma schema changes and migration for bank accounts and statements
- implement bank account CRUD endpoints with IBAN/BIC validation and statement recording logic
- cover new treasury flows with integration tests for account CRUD and balance checks

## Testing
- npm run lint
- npm test *(fails: local Postgres service is unavailable in the execution environment)*
- npm run build *(fails: web workspace lacks an index.html entry point)*

------
https://chatgpt.com/codex/tasks/task_e_68d02a16b5bc8323b2fae2ccb6a44917