### PR TITLE
feat: add donation receipts management

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -13,6 +13,7 @@
     "prisma:migrate": "prisma migrate dev"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "3.895.0",
     "@fastify/autoload": "6.3.1",
     "@fastify/env": "5.0.2",
     "@fastify/rate-limit": "10.3.0",

--- a/apps/api/prisma/migrations/20251005090000_add_donations/migration.sql
+++ b/apps/api/prisma/migrations/20251005090000_add_donations/migration.sql
@@ -1,0 +1,72 @@
+BEGIN;
+
+CREATE TABLE "public"."donation_receipt_sequence" (
+    "id" UUID NOT NULL DEFAULT uuid_generate_v7(),
+    "organization_id" UUID NOT NULL,
+    "fiscal_year_id" UUID NOT NULL,
+    "next_value" INTEGER NOT NULL DEFAULT 1,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "donation_receipt_sequence_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "donation_receipt_sequence_org_year_key" UNIQUE ("organization_id", "fiscal_year_id")
+);
+
+CREATE INDEX "donation_receipt_sequence_org_idx" ON "public"."donation_receipt_sequence"("organization_id");
+
+ALTER TABLE "public"."donation_receipt_sequence"
+    ADD CONSTRAINT "donation_receipt_sequence_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "public"."donation_receipt_sequence"
+    ADD CONSTRAINT "donation_receipt_sequence_fiscal_year_id_fkey" FOREIGN KEY ("fiscal_year_id") REFERENCES "public"."fiscal_year"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "public"."donation_receipt_sequence" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."donation_receipt_sequence" FORCE ROW LEVEL SECURITY;
+CREATE POLICY "donation_receipt_sequence_isolation" ON "public"."donation_receipt_sequence"
+  FOR ALL
+  USING ("organization_id" = current_setting('app.current_org')::uuid)
+  WITH CHECK ("organization_id" = current_setting('app.current_org')::uuid);
+
+CREATE TABLE "public"."donation" (
+    "id" UUID NOT NULL DEFAULT uuid_generate_v7(),
+    "organization_id" UUID NOT NULL,
+    "fiscal_year_id" UUID NOT NULL,
+    "entry_id" UUID NOT NULL,
+    "donor_name" TEXT NOT NULL,
+    "donor_email" TEXT,
+    "donor_address" TEXT,
+    "amount" DECIMAL(16,2) NOT NULL,
+    "currency" TEXT NOT NULL DEFAULT 'EUR',
+    "receipt_number" TEXT NOT NULL,
+    "receipt_hash" TEXT NOT NULL,
+    "receipt_url" TEXT NOT NULL,
+    "received_at" TIMESTAMP(3) NOT NULL,
+    "issued_at" TIMESTAMP(3) NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "donation_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "donation_entry_id_key" UNIQUE ("entry_id"),
+    CONSTRAINT "donation_receipt_unique" UNIQUE ("organization_id", "fiscal_year_id", "receipt_number")
+);
+
+CREATE INDEX "donation_org_fiscal_year_idx" ON "public"."donation"("organization_id", "fiscal_year_id");
+CREATE INDEX "donation_org_received_idx" ON "public"."donation"("organization_id", "received_at");
+
+ALTER TABLE "public"."donation"
+    ADD CONSTRAINT "donation_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "public"."donation"
+    ADD CONSTRAINT "donation_fiscal_year_id_fkey" FOREIGN KEY ("fiscal_year_id") REFERENCES "public"."fiscal_year"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "public"."donation"
+    ADD CONSTRAINT "donation_entry_id_fkey" FOREIGN KEY ("entry_id") REFERENCES "public"."entry"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "public"."donation" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."donation" FORCE ROW LEVEL SECURITY;
+CREATE POLICY "donation_isolation" ON "public"."donation"
+  FOR ALL
+  USING ("organization_id" = current_setting('app.current_org')::uuid)
+  WITH CHECK ("organization_id" = current_setting('app.current_org')::uuid);
+
+COMMIT;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -8,45 +8,49 @@ datasource db {
 }
 
 model Organization {
-  id          String       @id @default(dbgenerated("uuid_generate_v7()")) @db.Uuid
-  name        String
-  createdAt   DateTime     @default(now()) @map("created_at")
-  updatedAt   DateTime     @updatedAt @map("updated_at")
-  fiscalYears FiscalYear[]
-  accounts    Account[]
-  journals    Journal[]
-  entries     Entry[]
-  entryLines  EntryLine[]
-  attachments Attachment[]
-  memberships UserOrgRole[]
-  refreshTokens RefreshToken[]
-  sequences   SequenceNumber[]
-  fecExports  FecExport[]
-  bankAccounts BankAccount[]
-  bankStatements BankStatement[]
-  bankTransactions BankTransaction[]
-  ofxRules     OfxRule[]
-  members      Member[]
-  membershipFeeTemplates MembershipFeeTemplate[]
-  memberFeeAssignments MemberFeeAssignment[]
-  memberPayments MemberPayment[]
+  id                       String                    @id @default(dbgenerated("uuid_generate_v7()")) @db.Uuid
+  name                     String
+  createdAt                DateTime                  @default(now()) @map("created_at")
+  updatedAt                DateTime                  @updatedAt @map("updated_at")
+  fiscalYears              FiscalYear[]
+  accounts                 Account[]
+  journals                 Journal[]
+  entries                  Entry[]
+  entryLines               EntryLine[]
+  attachments              Attachment[]
+  memberships              UserOrgRole[]
+  refreshTokens            RefreshToken[]
+  sequences                SequenceNumber[]
+  fecExports               FecExport[]
+  bankAccounts             BankAccount[]
+  bankStatements           BankStatement[]
+  bankTransactions         BankTransaction[]
+  ofxRules                 OfxRule[]
+  members                  Member[]
+  membershipFeeTemplates   MembershipFeeTemplate[]
+  memberFeeAssignments     MemberFeeAssignment[]
+  memberPayments           MemberPayment[]
+  donations                Donation[]
+  donationReceiptSequences DonationReceiptSequence[]
 
   @@map("organization")
 }
 
 model FiscalYear {
-  id             String       @id @default(dbgenerated("uuid_generate_v7()")) @db.Uuid
-  organizationId String       @map("organization_id") @db.Uuid
-  label          String
-  startDate      DateTime     @map("start_date")
-  endDate        DateTime     @map("end_date")
-  lockedAt       DateTime?    @map("locked_at")
-  createdAt      DateTime     @default(now()) @map("created_at")
-  updatedAt      DateTime     @updatedAt @map("updated_at")
-  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Restrict)
-  entries        Entry[]
-  sequences      SequenceNumber[]
-  fecExports     FecExport[]
+  id                       String                    @id @default(dbgenerated("uuid_generate_v7()")) @db.Uuid
+  organizationId           String                    @map("organization_id") @db.Uuid
+  label                    String
+  startDate                DateTime                  @map("start_date")
+  endDate                  DateTime                  @map("end_date")
+  lockedAt                 DateTime?                 @map("locked_at")
+  createdAt                DateTime                  @default(now()) @map("created_at")
+  updatedAt                DateTime                  @updatedAt @map("updated_at")
+  organization             Organization              @relation(fields: [organizationId], references: [id], onDelete: Restrict)
+  entries                  Entry[]
+  sequences                SequenceNumber[]
+  fecExports               FecExport[]
+  donations                Donation[]
+  donationReceiptSequences DonationReceiptSequence[]
 
   @@unique([organizationId, label], map: "fiscal_year_org_label_key")
   @@index([organizationId, startDate], map: "fiscal_year_org_start_idx")
@@ -72,14 +76,14 @@ model Account {
 }
 
 model Journal {
-  id             String       @id @default(dbgenerated("uuid_generate_v7()")) @db.Uuid
-  organizationId String       @map("organization_id") @db.Uuid
+  id             String           @id @default(dbgenerated("uuid_generate_v7()")) @db.Uuid
+  organizationId String           @map("organization_id") @db.Uuid
   code           String
   name           String
   type           String
-  createdAt      DateTime     @default(now()) @map("created_at")
-  updatedAt      DateTime     @updatedAt @map("updated_at")
-  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Restrict)
+  createdAt      DateTime         @default(now()) @map("created_at")
+  updatedAt      DateTime         @updatedAt @map("updated_at")
+  organization   Organization     @relation(fields: [organizationId], references: [id], onDelete: Restrict)
   entries        Entry[]
   sequences      SequenceNumber[]
 
@@ -89,27 +93,28 @@ model Journal {
 }
 
 model Entry {
-  id             String       @id @default(dbgenerated("uuid_generate_v7()")) @db.Uuid
-  organizationId String       @map("organization_id") @db.Uuid
-  fiscalYearId   String       @map("fiscal_year_id") @db.Uuid
-  journalId      String       @map("journal_id") @db.Uuid
-  date           DateTime
-  reference      String?      @map("ref")
-  memo           String?
-  lockedAt       DateTime?    @map("locked_at")
-  createdBy      String?      @map("created_by")
-  bankStatementId String?     @map("bank_statement_id") @db.Uuid
-  createdAt      DateTime     @default(now()) @map("created_at")
-  updatedAt      DateTime     @updatedAt @map("updated_at")
-  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Restrict)
-  fiscalYear     FiscalYear   @relation(fields: [fiscalYearId], references: [id], onDelete: Restrict)
-  journal        Journal      @relation(fields: [journalId], references: [id], onDelete: Restrict)
-  lines          EntryLine[]
-  attachments    Attachment[]
-  bankStatement  BankStatement? @relation(fields: [bankStatementId], references: [id], onDelete: SetNull)
-  bankMatches    BankTransaction[] @relation("BankTransactionMatchedEntry")
+  id                   String                @id @default(dbgenerated("uuid_generate_v7()")) @db.Uuid
+  organizationId       String                @map("organization_id") @db.Uuid
+  fiscalYearId         String                @map("fiscal_year_id") @db.Uuid
+  journalId            String                @map("journal_id") @db.Uuid
+  date                 DateTime
+  reference            String?               @map("ref")
+  memo                 String?
+  lockedAt             DateTime?             @map("locked_at")
+  createdBy            String?               @map("created_by")
+  bankStatementId      String?               @map("bank_statement_id") @db.Uuid
+  createdAt            DateTime              @default(now()) @map("created_at")
+  updatedAt            DateTime              @updatedAt @map("updated_at")
+  organization         Organization          @relation(fields: [organizationId], references: [id], onDelete: Restrict)
+  fiscalYear           FiscalYear            @relation(fields: [fiscalYearId], references: [id], onDelete: Restrict)
+  journal              Journal               @relation(fields: [journalId], references: [id], onDelete: Restrict)
+  lines                EntryLine[]
+  attachments          Attachment[]
+  bankStatement        BankStatement?        @relation(fields: [bankStatementId], references: [id], onDelete: SetNull)
+  bankMatches          BankTransaction[]     @relation("BankTransactionMatchedEntry")
   memberFeeAssignments MemberFeeAssignment[]
-  memberPayments MemberPayment[]
+  memberPayments       MemberPayment[]
+  donations            Donation[]
 
   @@index([organizationId, date], map: "entry_org_date_idx")
   @@index([organizationId, fiscalYearId], map: "entry_org_fiscal_year_idx")
@@ -119,16 +124,16 @@ model Entry {
 }
 
 model BankAccount {
-  id             String       @id @default(dbgenerated("uuid_generate_v7()")) @db.Uuid
-  organizationId String       @map("organization_id") @db.Uuid
-  accountId      String       @map("account_id") @db.Uuid @unique
+  id             String            @id @default(dbgenerated("uuid_generate_v7()")) @db.Uuid
+  organizationId String            @map("organization_id") @db.Uuid
+  accountId      String            @unique @map("account_id") @db.Uuid
   name           String
   iban           String
   bic            String?
-  createdAt      DateTime     @default(now()) @map("created_at")
-  updatedAt      DateTime     @updatedAt @map("updated_at")
-  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Restrict)
-  account        Account      @relation(fields: [accountId], references: [id], onDelete: Restrict)
+  createdAt      DateTime          @default(now()) @map("created_at")
+  updatedAt      DateTime          @updatedAt @map("updated_at")
+  organization   Organization      @relation(fields: [organizationId], references: [id], onDelete: Restrict)
+  account        Account           @relation(fields: [accountId], references: [id], onDelete: Restrict)
   statements     BankStatement[]
   transactions   BankTransaction[]
   ofxRules       OfxRule[]
@@ -140,16 +145,16 @@ model BankAccount {
 }
 
 model BankStatement {
-  id             String        @id @default(dbgenerated("uuid_generate_v7()")) @db.Uuid
-  organizationId String        @map("organization_id") @db.Uuid
-  bankAccountId  String        @map("bank_account_id") @db.Uuid
-  statementDate  DateTime      @map("statement_date")
-  openingBalance Decimal       @map("opening_balance") @db.Decimal(16, 2)
-  closingBalance Decimal       @map("closing_balance") @db.Decimal(16, 2)
-  createdAt      DateTime      @default(now()) @map("created_at")
-  updatedAt      DateTime      @updatedAt @map("updated_at")
-  organization   Organization  @relation(fields: [organizationId], references: [id], onDelete: Restrict)
-  bankAccount    BankAccount   @relation(fields: [bankAccountId], references: [id], onDelete: Restrict)
+  id             String            @id @default(dbgenerated("uuid_generate_v7()")) @db.Uuid
+  organizationId String            @map("organization_id") @db.Uuid
+  bankAccountId  String            @map("bank_account_id") @db.Uuid
+  statementDate  DateTime          @map("statement_date")
+  openingBalance Decimal           @map("opening_balance") @db.Decimal(16, 2)
+  closingBalance Decimal           @map("closing_balance") @db.Decimal(16, 2)
+  createdAt      DateTime          @default(now()) @map("created_at")
+  updatedAt      DateTime          @updatedAt @map("updated_at")
+  organization   Organization      @relation(fields: [organizationId], references: [id], onDelete: Restrict)
+  bankAccount    BankAccount       @relation(fields: [bankAccountId], references: [id], onDelete: Restrict)
   entries        Entry[]
   transactions   BankTransaction[]
 
@@ -159,23 +164,23 @@ model BankStatement {
 }
 
 model BankTransaction {
-  id              String        @id @default(dbgenerated("uuid_generate_v7()")) @db.Uuid
-  organizationId  String        @map("organization_id") @db.Uuid
-  bankAccountId   String        @map("bank_account_id") @db.Uuid
-  bankStatementId String?       @map("bank_statement_id") @db.Uuid
-  fitId           String        @map("fitid")
-  valueDate       DateTime      @map("value_date")
-  amount          Decimal       @db.Decimal(16, 2)
-  rawLabel        String        @map("raw_label")
-  normalizedLabel String?       @map("normalized_label")
+  id              String         @id @default(dbgenerated("uuid_generate_v7()")) @db.Uuid
+  organizationId  String         @map("organization_id") @db.Uuid
+  bankAccountId   String         @map("bank_account_id") @db.Uuid
+  bankStatementId String?        @map("bank_statement_id") @db.Uuid
+  fitId           String         @map("fitid")
+  valueDate       DateTime       @map("value_date")
+  amount          Decimal        @db.Decimal(16, 2)
+  rawLabel        String         @map("raw_label")
+  normalizedLabel String?        @map("normalized_label")
   memo            String?
-  matchedEntryId  String?       @map("matched_entry_id") @db.Uuid
-  createdAt       DateTime      @default(now()) @map("created_at")
-  updatedAt       DateTime      @updatedAt @map("updated_at")
-  organization    Organization  @relation(fields: [organizationId], references: [id], onDelete: Restrict)
-  bankAccount     BankAccount   @relation(fields: [bankAccountId], references: [id], onDelete: Restrict)
+  matchedEntryId  String?        @map("matched_entry_id") @db.Uuid
+  createdAt       DateTime       @default(now()) @map("created_at")
+  updatedAt       DateTime       @updatedAt @map("updated_at")
+  organization    Organization   @relation(fields: [organizationId], references: [id], onDelete: Restrict)
+  bankAccount     BankAccount    @relation(fields: [bankAccountId], references: [id], onDelete: Restrict)
   bankStatement   BankStatement? @relation(fields: [bankStatementId], references: [id], onDelete: SetNull)
-  matchedEntry    Entry?        @relation("BankTransactionMatchedEntry", fields: [matchedEntryId], references: [id], onDelete: SetNull)
+  matchedEntry    Entry?         @relation("BankTransactionMatchedEntry", fields: [matchedEntryId], references: [id], onDelete: SetNull)
 
   @@unique([bankAccountId, fitId, amount, valueDate], map: "bank_transaction_dedup_key")
   @@index([organizationId, bankAccountId, valueDate], map: "bank_transaction_org_account_date_idx")
@@ -251,18 +256,18 @@ model EntryLine {
 }
 
 model Member {
-  id             String       @id @default(dbgenerated("uuid_generate_v7()")) @db.Uuid
-  organizationId String       @map("organization_id") @db.Uuid
-  firstName      String       @map("first_name")
-  lastName       String       @map("last_name")
+  id             String                @id @default(dbgenerated("uuid_generate_v7()")) @db.Uuid
+  organizationId String                @map("organization_id") @db.Uuid
+  firstName      String                @map("first_name")
+  lastName       String                @map("last_name")
   email          String
-  membershipType String       @map("membership_type")
-  joinedAt       DateTime?    @map("joined_at")
-  leftAt         DateTime?    @map("left_at")
-  rgpdConsentAt  DateTime?    @map("rgpd_consent_at")
-  createdAt      DateTime     @default(now()) @map("created_at")
-  updatedAt      DateTime     @updatedAt @map("updated_at")
-  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Restrict)
+  membershipType String                @map("membership_type")
+  joinedAt       DateTime?             @map("joined_at")
+  leftAt         DateTime?             @map("left_at")
+  rgpdConsentAt  DateTime?             @map("rgpd_consent_at")
+  createdAt      DateTime              @default(now()) @map("created_at")
+  updatedAt      DateTime              @updatedAt @map("updated_at")
+  organization   Organization          @relation(fields: [organizationId], references: [id], onDelete: Restrict)
   feeAssignments MemberFeeAssignment[]
   entryLines     EntryLine[]
   payments       MemberPayment[]
@@ -274,18 +279,18 @@ model Member {
 }
 
 model MembershipFeeTemplate {
-  id             String       @id @default(dbgenerated("uuid_generate_v7()")) @db.Uuid
-  organizationId String       @map("organization_id") @db.Uuid
+  id             String                @id @default(dbgenerated("uuid_generate_v7()")) @db.Uuid
+  organizationId String                @map("organization_id") @db.Uuid
   label          String
-  amount         Decimal      @db.Decimal(16, 2)
-  currency       String       @default("EUR")
-  membershipType String?      @map("membership_type")
-  validFrom      DateTime     @map("valid_from")
-  validUntil     DateTime?    @map("valid_until")
-  isActive       Boolean      @default(true) @map("is_active")
-  createdAt      DateTime     @default(now()) @map("created_at")
-  updatedAt      DateTime     @updatedAt @map("updated_at")
-  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Restrict)
+  amount         Decimal               @db.Decimal(16, 2)
+  currency       String                @default("EUR")
+  membershipType String?               @map("membership_type")
+  validFrom      DateTime              @map("valid_from")
+  validUntil     DateTime?             @map("valid_until")
+  isActive       Boolean               @default(true) @map("is_active")
+  createdAt      DateTime              @default(now()) @map("created_at")
+  updatedAt      DateTime              @updatedAt @map("updated_at")
+  organization   Organization          @relation(fields: [organizationId], references: [id], onDelete: Restrict)
   assignments    MemberFeeAssignment[]
 
   @@index([organizationId, isActive], map: "membership_fee_template_org_active_idx")
@@ -295,26 +300,26 @@ model MembershipFeeTemplate {
 }
 
 model MemberFeeAssignment {
-  id             String                     @id @default(dbgenerated("uuid_generate_v7()")) @db.Uuid
-  organizationId String                     @map("organization_id") @db.Uuid
-  memberId       String                     @map("member_id") @db.Uuid
-  templateId     String                     @map("template_id") @db.Uuid
-  amount         Decimal                    @db.Decimal(16, 2)
-  currency       String                     @default("EUR")
-  status         MemberFeeAssignmentStatus  @default(PENDING)
-  periodStart    DateTime                   @map("period_start")
-  periodEnd      DateTime?                  @map("period_end")
-  dueDate        DateTime?                  @map("due_date")
-  assignedAt     DateTime                   @default(now()) @map("assigned_at")
-  autoAssigned   Boolean                    @default(false) @map("auto_assigned")
-  entryId        String?                    @map("entry_id") @db.Uuid
-  draftInvoiceId String?                    @map("draft_invoice_id")
-  createdAt      DateTime                   @default(now()) @map("created_at")
-  updatedAt      DateTime                   @updatedAt @map("updated_at")
-  organization   Organization               @relation(fields: [organizationId], references: [id], onDelete: Restrict)
-  member         Member                     @relation(fields: [memberId], references: [id], onDelete: Restrict)
-  template       MembershipFeeTemplate      @relation(fields: [templateId], references: [id], onDelete: Restrict)
-  entry          Entry?                     @relation(fields: [entryId], references: [id], onDelete: SetNull)
+  id             String                    @id @default(dbgenerated("uuid_generate_v7()")) @db.Uuid
+  organizationId String                    @map("organization_id") @db.Uuid
+  memberId       String                    @map("member_id") @db.Uuid
+  templateId     String                    @map("template_id") @db.Uuid
+  amount         Decimal                   @db.Decimal(16, 2)
+  currency       String                    @default("EUR")
+  status         MemberFeeAssignmentStatus @default(PENDING)
+  periodStart    DateTime                  @map("period_start")
+  periodEnd      DateTime?                 @map("period_end")
+  dueDate        DateTime?                 @map("due_date")
+  assignedAt     DateTime                  @default(now()) @map("assigned_at")
+  autoAssigned   Boolean                   @default(false) @map("auto_assigned")
+  entryId        String?                   @map("entry_id") @db.Uuid
+  draftInvoiceId String?                   @map("draft_invoice_id")
+  createdAt      DateTime                  @default(now()) @map("created_at")
+  updatedAt      DateTime                  @updatedAt @map("updated_at")
+  organization   Organization              @relation(fields: [organizationId], references: [id], onDelete: Restrict)
+  member         Member                    @relation(fields: [memberId], references: [id], onDelete: Restrict)
+  template       MembershipFeeTemplate     @relation(fields: [templateId], references: [id], onDelete: Restrict)
+  entry          Entry?                    @relation(fields: [entryId], references: [id], onDelete: SetNull)
   payments       MemberPayment[]
 
   @@unique([organizationId, memberId, templateId, periodStart], map: "member_fee_assignment_unique_period")
@@ -325,17 +330,17 @@ model MemberFeeAssignment {
 }
 
 model Attachment {
-  id             String       @id @default(dbgenerated("uuid_generate_v7()")) @db.Uuid
-  organizationId String       @map("organization_id") @db.Uuid
-  entryId        String       @map("entry_id") @db.Uuid
+  id             String          @id @default(dbgenerated("uuid_generate_v7()")) @db.Uuid
+  organizationId String          @map("organization_id") @db.Uuid
+  entryId        String          @map("entry_id") @db.Uuid
   url            String
   filename       String
   mime           String
   sha256         String
-  createdAt      DateTime     @default(now()) @map("created_at")
-  updatedAt      DateTime     @updatedAt @map("updated_at")
-  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Restrict)
-  entry          Entry        @relation(fields: [entryId], references: [id], onDelete: Cascade)
+  createdAt      DateTime        @default(now()) @map("created_at")
+  updatedAt      DateTime        @updatedAt @map("updated_at")
+  organization   Organization    @relation(fields: [organizationId], references: [id], onDelete: Restrict)
+  entry          Entry           @relation(fields: [entryId], references: [id], onDelete: Cascade)
   memberPayments MemberPayment[] @relation("MemberPaymentSupportingDocument")
 
   @@index([organizationId, entryId], map: "attachment_org_entry_idx")
@@ -343,11 +348,11 @@ model Attachment {
 }
 
 model User {
-  id            String          @id @default(dbgenerated("uuid_generate_v7()")) @db.Uuid
-  email         String          @unique
-  passwordHash  String          @map("password_hash")
-  createdAt     DateTime        @default(now()) @map("created_at")
-  updatedAt     DateTime        @updatedAt @map("updated_at")
+  id            String         @id @default(dbgenerated("uuid_generate_v7()")) @db.Uuid
+  email         String         @unique
+  passwordHash  String         @map("password_hash")
+  createdAt     DateTime       @default(now()) @map("created_at")
+  updatedAt     DateTime       @updatedAt @map("updated_at")
   roles         UserOrgRole[]
   refreshTokens RefreshToken[]
 
@@ -370,17 +375,17 @@ model UserOrgRole {
 }
 
 model RefreshToken {
-  id                String        @id @default(dbgenerated("uuid_generate_v7()")) @db.Uuid
-  userId            String        @map("user_id") @db.Uuid
-  organizationId    String        @map("organization_id") @db.Uuid
-  expiresAt         DateTime      @map("expires_at")
-  revokedAt         DateTime?     @map("revoked_at")
-  replacedByTokenId String?       @map("replaced_by_token_id") @db.Uuid
-  createdAt         DateTime      @default(now()) @map("created_at")
-  updatedAt         DateTime      @updatedAt @map("updated_at")
-  user              User          @relation(fields: [userId], references: [id], onDelete: Cascade)
-  organization      Organization  @relation(fields: [organizationId], references: [id], onDelete: Restrict)
-  replacedBy        RefreshToken? @relation("RefreshTokenReplacement", fields: [replacedByTokenId], references: [id])
+  id                String         @id @default(dbgenerated("uuid_generate_v7()")) @db.Uuid
+  userId            String         @map("user_id") @db.Uuid
+  organizationId    String         @map("organization_id") @db.Uuid
+  expiresAt         DateTime       @map("expires_at")
+  revokedAt         DateTime?      @map("revoked_at")
+  replacedByTokenId String?        @map("replaced_by_token_id") @db.Uuid
+  createdAt         DateTime       @default(now()) @map("created_at")
+  updatedAt         DateTime       @updatedAt @map("updated_at")
+  user              User           @relation(fields: [userId], references: [id], onDelete: Cascade)
+  organization      Organization   @relation(fields: [organizationId], references: [id], onDelete: Restrict)
+  replacedBy        RefreshToken?  @relation("RefreshTokenReplacement", fields: [replacedByTokenId], references: [id])
   replacements      RefreshToken[] @relation("RefreshTokenReplacement")
 
   @@index([userId, organizationId], map: "refresh_token_user_org_idx")
@@ -408,26 +413,69 @@ enum MemberPaymentStatus {
 }
 
 model MemberPayment {
-  id                    String               @id @default(dbgenerated("uuid_generate_v7()")) @db.Uuid
-  organizationId        String               @map("organization_id") @db.Uuid
-  assignmentId          String               @map("assignment_id") @db.Uuid @unique
-  memberId              String               @map("member_id") @db.Uuid
-  status                MemberPaymentStatus  @default(PENDING)
-  amount                Decimal              @db.Decimal(16, 2)
-  currency              String               @default("EUR")
-  dueDate               DateTime?            @map("due_date")
-  paidAt                DateTime?            @map("paid_at")
-  entryId               String?              @map("entry_id") @db.Uuid
-  supportingDocumentId  String?              @map("supporting_document_id") @db.Uuid
-  createdAt             DateTime             @default(now()) @map("created_at")
-  updatedAt             DateTime             @updatedAt @map("updated_at")
-  organization          Organization         @relation(fields: [organizationId], references: [id], onDelete: Restrict)
-  assignment            MemberFeeAssignment  @relation(fields: [assignmentId], references: [id], onDelete: Cascade)
-  member                Member               @relation(fields: [memberId], references: [id], onDelete: Restrict)
-  entry                 Entry?               @relation(fields: [entryId], references: [id], onDelete: SetNull)
-  supportingDocument    Attachment?          @relation("MemberPaymentSupportingDocument", fields: [supportingDocumentId], references: [id], onDelete: SetNull)
+  id                   String              @id @default(dbgenerated("uuid_generate_v7()")) @db.Uuid
+  organizationId       String              @map("organization_id") @db.Uuid
+  assignmentId         String              @unique @map("assignment_id") @db.Uuid
+  memberId             String              @map("member_id") @db.Uuid
+  status               MemberPaymentStatus @default(PENDING)
+  amount               Decimal             @db.Decimal(16, 2)
+  currency             String              @default("EUR")
+  dueDate              DateTime?           @map("due_date")
+  paidAt               DateTime?           @map("paid_at")
+  entryId              String?             @map("entry_id") @db.Uuid
+  supportingDocumentId String?             @map("supporting_document_id") @db.Uuid
+  createdAt            DateTime            @default(now()) @map("created_at")
+  updatedAt            DateTime            @updatedAt @map("updated_at")
+  organization         Organization        @relation(fields: [organizationId], references: [id], onDelete: Restrict)
+  assignment           MemberFeeAssignment @relation(fields: [assignmentId], references: [id], onDelete: Cascade)
+  member               Member              @relation(fields: [memberId], references: [id], onDelete: Restrict)
+  entry                Entry?              @relation(fields: [entryId], references: [id], onDelete: SetNull)
+  supportingDocument   Attachment?         @relation("MemberPaymentSupportingDocument", fields: [supportingDocumentId], references: [id], onDelete: SetNull)
 
   @@index([organizationId, status], map: "member_payment_org_status_idx")
   @@index([organizationId, dueDate], map: "member_payment_org_due_date_idx")
   @@map("member_payment")
+}
+
+model DonationReceiptSequence {
+  id             String       @id @default(dbgenerated("uuid_generate_v7()")) @db.Uuid
+  organizationId String       @map("organization_id") @db.Uuid
+  fiscalYearId   String       @map("fiscal_year_id") @db.Uuid
+  nextValue      Int          @default(1) @map("next_value")
+  createdAt      DateTime     @default(now()) @map("created_at")
+  updatedAt      DateTime     @updatedAt @map("updated_at")
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Restrict)
+  fiscalYear     FiscalYear   @relation(fields: [fiscalYearId], references: [id], onDelete: Restrict)
+
+  @@unique([organizationId, fiscalYearId], map: "donation_receipt_sequence_org_year_key")
+  @@index([organizationId], map: "donation_receipt_sequence_org_idx")
+  @@map("donation_receipt_sequence")
+}
+
+model Donation {
+  id             String       @id @default(dbgenerated("uuid_generate_v7()")) @db.Uuid
+  organizationId String       @map("organization_id") @db.Uuid
+  fiscalYearId   String       @map("fiscal_year_id") @db.Uuid
+  entryId        String       @map("entry_id") @db.Uuid
+  donorName      String       @map("donor_name")
+  donorEmail     String?      @map("donor_email")
+  donorAddress   String?      @map("donor_address")
+  amount         Decimal      @db.Decimal(16, 2)
+  currency       String       @default("EUR")
+  receiptNumber  String       @map("receipt_number")
+  receiptHash    String       @map("receipt_hash")
+  receiptUrl     String       @map("receipt_url")
+  receivedAt     DateTime     @map("received_at")
+  issuedAt       DateTime     @map("issued_at")
+  createdAt      DateTime     @default(now()) @map("created_at")
+  updatedAt      DateTime     @updatedAt @map("updated_at")
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Restrict)
+  fiscalYear     FiscalYear   @relation(fields: [fiscalYearId], references: [id], onDelete: Restrict)
+  entry          Entry        @relation(fields: [entryId], references: [id], onDelete: Restrict)
+
+  @@unique([entryId], map: "donation_entry_id_key")
+  @@unique([organizationId, fiscalYearId, receiptNumber], map: "donation_receipt_unique")
+  @@index([organizationId, fiscalYearId], map: "donation_org_fiscal_year_idx")
+  @@index([organizationId, receivedAt], map: "donation_org_received_idx")
+  @@map("donation")
 }

--- a/apps/api/src/__tests__/donations.http.test.ts
+++ b/apps/api/src/__tests__/donations.http.test.ts
@@ -1,0 +1,401 @@
+import { createHash } from 'node:crypto';
+import type { FastifyInstance } from 'fastify';
+import request from 'supertest';
+import { beforeAll, afterAll, beforeEach, describe, expect, it } from 'vitest';
+import { Prisma, PrismaClient, UserRole } from '@prisma/client';
+import buildServer from '../server';
+import {
+  applyTenantContext,
+  createPrismaClient,
+  resetDatabase,
+  setupTestDatabase,
+  teardownTestDatabase,
+} from './helpers/database';
+import type { ObjectStorage } from '../plugins/object-storage';
+
+const TEST_ACCESS_SECRET = 'test-access-secret-change-me-12345678901234567890';
+const TEST_REFRESH_SECRET = 'test-refresh-secret-change-me-12345678901234567890';
+
+interface StoredObject {
+  key: string;
+  body: Buffer;
+  contentType: string;
+}
+
+let app: FastifyInstance;
+let prisma: PrismaClient;
+let storedObjects: StoredObject[];
+
+beforeAll(async () => {
+  process.env.JWT_ACCESS_SECRET = TEST_ACCESS_SECRET;
+  process.env.JWT_REFRESH_SECRET = TEST_REFRESH_SECRET;
+  process.env.REFRESH_TOKEN_TTL_DAYS = '30';
+  process.env.NODE_ENV = 'test';
+  process.env.S3_ACCESS_KEY_ID = 'test-access';
+  process.env.S3_SECRET_ACCESS_KEY = 'test-secret';
+  process.env.S3_BUCKET = 'test-bucket';
+  process.env.S3_REGION = 'eu-west-1';
+  process.env.S3_ENDPOINT = 'http://localhost:9000';
+  process.env.S3_PUBLIC_URL = 'https://cdn.example.org/storage';
+
+  await setupTestDatabase();
+
+  prisma = createPrismaClient();
+  await prisma.$connect();
+
+  app = await buildServer();
+  await app.ready();
+
+  storedObjects = [];
+  const stubStorage: ObjectStorage = {
+    async putObject({ key, body, contentType }) {
+      const buffer = Buffer.isBuffer(body) ? body : Buffer.from(body);
+      storedObjects.push({ key, body: buffer, contentType });
+      return { url: `https://cdn.example.org/storage/${key}` };
+    },
+    getPublicUrl(key: string) {
+      return `https://cdn.example.org/storage/${key}`;
+    },
+  };
+
+  app.objectStorage = stubStorage;
+  app.addHook('onRequest', (request, _reply, done) => {
+    request.objectStorage = app.objectStorage;
+    done();
+  });
+});
+
+afterAll(async () => {
+  await app.close();
+  await prisma.$disconnect();
+  await teardownTestDatabase();
+});
+
+beforeEach(async () => {
+  storedObjects = [];
+  await resetDatabase();
+});
+
+describe('donations HTTP routes', () => {
+  it('issues sequential receipts per fiscal year and stores compliant PDFs', async () => {
+    const { organizationId, accessToken } = await createUserWithRole(UserRole.TREASURER);
+    const fixtures = await seedDonationFixtures(organizationId);
+
+    const entry2025A = await createBalancedEntry(organizationId, {
+      fiscalYearId: fixtures.fiscalYear2025.id,
+      journalId: fixtures.journal.id,
+      debitAccountId: fixtures.debitAccount.id,
+      creditAccountId: fixtures.creditAccount.id,
+      amount: '150.00',
+      date: '2025-03-10',
+      reference: 'DON-ENTRY-2025-A',
+    });
+
+    const firstResponse = await request(app.server)
+      .post(`/api/v1/orgs/${organizationId}/donations`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({
+        entryId: entry2025A.id,
+        amount: '150.00',
+        receivedAt: '2025-03-10',
+        donor: { name: 'Alice Martin', email: 'alice@example.org' },
+      });
+
+    expect(firstResponse.statusCode).toBe(201);
+    expect(firstResponse.body.data.receiptNumber).toBe('2025-DON-000001');
+    expect(firstResponse.body.data.receiptUrl).toMatch(
+      /^https:\/\/cdn\.example\.org\/storage\/donations\//
+    );
+    expect(storedObjects).toHaveLength(1);
+    expect(storedObjects[0].contentType).toBe('application/pdf');
+    expect(storedObjects[0].body.subarray(0, 4).toString()).toBe('%PDF');
+
+    const expectedHash = createHash('sha256').update(storedObjects[0].body).digest('hex');
+    expect(firstResponse.body.data.receiptHash).toBe(expectedHash);
+
+    const pdfText = storedObjects[0].body.toString('latin1');
+    expect(pdfText).toContain('Reçu fiscal de don');
+    expect(pdfText).toContain('Alice Martin');
+    expect(pdfText).toContain('150,00');
+
+    const entry2025B = await createBalancedEntry(organizationId, {
+      fiscalYearId: fixtures.fiscalYear2025.id,
+      journalId: fixtures.journal.id,
+      debitAccountId: fixtures.debitAccount.id,
+      creditAccountId: fixtures.creditAccount.id,
+      amount: '90.00',
+      date: '2025-05-20',
+      reference: 'DON-ENTRY-2025-B',
+    });
+
+    const secondResponse = await request(app.server)
+      .post(`/api/v1/orgs/${organizationId}/donations`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({
+        entryId: entry2025B.id,
+        amount: '90.00',
+        receivedAt: '2025-05-20',
+        donor: { name: 'Bob Leroy' },
+      });
+
+    expect(secondResponse.statusCode).toBe(201);
+    expect(secondResponse.body.data.receiptNumber).toBe('2025-DON-000002');
+
+    const entry2026 = await createBalancedEntry(organizationId, {
+      fiscalYearId: fixtures.fiscalYear2026.id,
+      journalId: fixtures.journal.id,
+      debitAccountId: fixtures.debitAccount.id,
+      creditAccountId: fixtures.creditAccount.id,
+      amount: '120.00',
+      date: '2026-02-12',
+      reference: 'DON-ENTRY-2026-A',
+    });
+
+    const thirdResponse = await request(app.server)
+      .post(`/api/v1/orgs/${organizationId}/donations`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({
+        entryId: entry2026.id,
+        amount: '120.00',
+        receivedAt: '2026-02-12',
+        donor: { name: 'Carla Dupont' },
+      });
+
+    expect(thirdResponse.statusCode).toBe(201);
+    expect(thirdResponse.body.data.receiptNumber).toBe('2026-DON-000001');
+    expect(storedObjects).toHaveLength(3);
+  });
+
+  it('lists donations with pagination metadata', async () => {
+    const { organizationId, accessToken } = await createUserWithRole(UserRole.TREASURER);
+    const fixtures = await seedDonationFixtures(organizationId);
+
+    const entryA = await createBalancedEntry(organizationId, {
+      fiscalYearId: fixtures.fiscalYear2025.id,
+      journalId: fixtures.journal.id,
+      debitAccountId: fixtures.debitAccount.id,
+      creditAccountId: fixtures.creditAccount.id,
+      amount: '60.00',
+      date: '2025-01-15',
+      reference: 'DON-LIST-A',
+    });
+    const entryB = await createBalancedEntry(organizationId, {
+      fiscalYearId: fixtures.fiscalYear2025.id,
+      journalId: fixtures.journal.id,
+      debitAccountId: fixtures.debitAccount.id,
+      creditAccountId: fixtures.creditAccount.id,
+      amount: '80.00',
+      date: '2025-02-20',
+      reference: 'DON-LIST-B',
+    });
+    const entryC = await createBalancedEntry(organizationId, {
+      fiscalYearId: fixtures.fiscalYear2025.id,
+      journalId: fixtures.journal.id,
+      debitAccountId: fixtures.debitAccount.id,
+      creditAccountId: fixtures.creditAccount.id,
+      amount: '40.00',
+      date: '2025-03-10',
+      reference: 'DON-LIST-C',
+    });
+
+    await createDonationViaApi(organizationId, accessToken, entryA.id, '60.00', '2025-01-15', 'Donateur A');
+    await createDonationViaApi(organizationId, accessToken, entryB.id, '80.00', '2025-02-20', 'Donateur B');
+    await createDonationViaApi(organizationId, accessToken, entryC.id, '40.00', '2025-03-10', 'Donateur C');
+
+    const listResponse = await request(app.server)
+      .get(`/api/v1/orgs/${organizationId}/donations`)
+      .query({ page: 1, limit: 2 })
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(listResponse.statusCode).toBe(200);
+    expect(listResponse.body.data).toHaveLength(2);
+    expect(listResponse.body.meta).toEqual({ total: 3, page: 1, limit: 2 });
+    expect(listResponse.body.data[0].receiptNumber).toBe('2025-DON-000003');
+    expect(listResponse.body.data[1].receiptNumber).toBe('2025-DON-000002');
+  });
+
+  it('exports annual donations as CSV', async () => {
+    const { organizationId, accessToken } = await createUserWithRole(UserRole.TREASURER);
+    const fixtures = await seedDonationFixtures(organizationId);
+
+    const entryA = await createBalancedEntry(organizationId, {
+      fiscalYearId: fixtures.fiscalYear2025.id,
+      journalId: fixtures.journal.id,
+      debitAccountId: fixtures.debitAccount.id,
+      creditAccountId: fixtures.creditAccount.id,
+      amount: '110.00',
+      date: '2025-06-01',
+      reference: 'DON-CSV-A',
+    });
+    const entryB = await createBalancedEntry(organizationId, {
+      fiscalYearId: fixtures.fiscalYear2025.id,
+      journalId: fixtures.journal.id,
+      debitAccountId: fixtures.debitAccount.id,
+      creditAccountId: fixtures.creditAccount.id,
+      amount: '95.00',
+      date: '2025-09-12',
+      reference: 'DON-CSV-B',
+    });
+
+    await createDonationViaApi(organizationId, accessToken, entryA.id, '110.00', '2025-06-01', 'Export Alice');
+    await createDonationViaApi(organizationId, accessToken, entryB.id, '95.00', '2025-09-12', 'Export Bob');
+
+    const exportResponse = await request(app.server)
+      .get(`/api/v1/orgs/${organizationId}/donations/export`)
+      .query({ fiscalYearId: fixtures.fiscalYear2025.id })
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(exportResponse.statusCode).toBe(200);
+    expect(exportResponse.headers['content-type']).toBe('text/csv; charset=utf-8');
+    expect(exportResponse.headers['content-disposition']).toBe(
+      'attachment; filename="donations-FY2025.csv"'
+    );
+    const csvBody = exportResponse.text;
+    expect(csvBody).toContain('Receipt Number;Received At;Issued At;Donor Name');
+    expect(csvBody).toContain('2025-DON-000001');
+    expect(csvBody).toContain('2025-DON-000002');
+  });
+});
+
+async function createUserWithRole(role: UserRole) {
+  const organization = await prisma.organization.create({ data: { name: `Org ${Date.now()}` } });
+  const user = await prisma.user.create({
+    data: {
+      email: `user+${Math.random().toString(16).slice(2)}@example.org`,
+      passwordHash: 'test-hash',
+    },
+  });
+
+  await prisma.userOrgRole.create({
+    data: {
+      organizationId: organization.id,
+      userId: user.id,
+      role,
+    },
+  });
+
+  const accessToken = app.issueAccessToken({
+    userId: user.id,
+    organizationId: organization.id,
+    roles: [role],
+  });
+
+  return { organizationId: organization.id, accessToken };
+}
+
+async function seedDonationFixtures(organizationId: string) {
+  return prisma.$transaction(async (tx) => {
+    await applyTenantContext(tx, organizationId);
+
+    const fiscalYear2025 = await tx.fiscalYear.create({
+      data: {
+        organizationId,
+        label: 'FY2025',
+        startDate: new Date('2025-01-01'),
+        endDate: new Date('2025-12-31'),
+      },
+    });
+
+    const fiscalYear2026 = await tx.fiscalYear.create({
+      data: {
+        organizationId,
+        label: 'FY2026',
+        startDate: new Date('2026-01-01'),
+        endDate: new Date('2026-12-31'),
+      },
+    });
+
+    const journal = await tx.journal.create({
+      data: {
+        organizationId,
+        code: 'BAN',
+        name: 'Banque',
+        type: 'BANK',
+      },
+    });
+
+    const debitAccount = await tx.account.create({
+      data: {
+        organizationId,
+        code: '512000',
+        name: 'Banque',
+        type: 'ASSET',
+      },
+    });
+
+    const creditAccount = await tx.account.create({
+      data: {
+        organizationId,
+        code: '756000',
+        name: 'Dons manuels',
+        type: 'REVENUE',
+      },
+    });
+
+    return { fiscalYear2025, fiscalYear2026, journal, debitAccount, creditAccount };
+  });
+}
+
+interface EntryOptions {
+  fiscalYearId: string;
+  journalId: string;
+  debitAccountId: string;
+  creditAccountId: string;
+  amount: string;
+  date: string;
+  reference: string;
+}
+
+async function createBalancedEntry(organizationId: string, options: EntryOptions) {
+  return prisma.$transaction(async (tx) => {
+    await applyTenantContext(tx, organizationId);
+
+    return tx.entry.create({
+      data: {
+        organizationId,
+        fiscalYearId: options.fiscalYearId,
+        journalId: options.journalId,
+        date: new Date(options.date),
+        reference: options.reference,
+        lines: {
+          create: [
+            {
+              organizationId,
+              accountId: options.debitAccountId,
+              debit: new Prisma.Decimal(options.amount),
+              credit: new Prisma.Decimal(0),
+            },
+            {
+              organizationId,
+              accountId: options.creditAccountId,
+              debit: new Prisma.Decimal(0),
+              credit: new Prisma.Decimal(options.amount),
+            },
+          ],
+        },
+      },
+    });
+  });
+}
+
+async function createDonationViaApi(
+  organizationId: string,
+  accessToken: string,
+  entryId: string,
+  amount: string,
+  receivedAt: string,
+  donorName: string
+) {
+  const response = await request(app.server)
+    .post(`/api/v1/orgs/${organizationId}/donations`)
+    .set('Authorization', `Bearer ${accessToken}`)
+    .send({
+      entryId,
+      amount,
+      receivedAt,
+      donor: { name: donorName },
+    });
+
+  expect(response.statusCode).toBe(201);
+  return response.body.data;
+}

--- a/apps/api/src/__tests__/helpers/database.ts
+++ b/apps/api/src/__tests__/helpers/database.ts
@@ -74,7 +74,7 @@ export async function resetDatabase(): Promise<void> {
   const adminClient = new PgClient({ connectionString: buildAdminDatabaseUrl(currentDatabaseName) });
   await adminClient.connect();
   await adminClient.query(
-    'TRUNCATE TABLE "refresh_token", "user_org_role", "user", "member_payment", "member_fee_assignment", "membership_fee_template", "member", "attachment", "fec_export", "bank_transaction", "ofx_rule", "entry_line", "entry", "bank_statement", "bank_account", "sequence_number", "journal", "account", "fiscal_year", "organization" RESTART IDENTITY CASCADE'
+    'TRUNCATE TABLE "refresh_token", "user_org_role", "user", "member_payment", "member_fee_assignment", "membership_fee_template", "member", "attachment", "fec_export", "bank_transaction", "ofx_rule", "donation", "entry_line", "entry", "bank_statement", "bank_account", "donation_receipt_sequence", "sequence_number", "journal", "account", "fiscal_year", "organization" RESTART IDENTITY CASCADE'
   );
   await adminClient.end();
 }

--- a/apps/api/src/modules/donations/index.ts
+++ b/apps/api/src/modules/donations/index.ts
@@ -1,0 +1,8 @@
+export { createDonation, listDonations, exportDonations } from './service';
+export {
+  createDonationInputSchema,
+  listDonationsQuerySchema,
+  donationExportQuerySchema,
+  type DonationExportQuery,
+  type ListDonationsQuery,
+} from './schemas';

--- a/apps/api/src/modules/donations/pdf.ts
+++ b/apps/api/src/modules/donations/pdf.ts
@@ -1,0 +1,207 @@
+import { PDFDocument, StandardFonts } from 'pdf-lib';
+import type { Decimal } from '@prisma/client/runtime/library';
+
+export interface DonationReceiptDetails {
+  organizationName: string;
+  organizationId: string;
+  fiscalYearLabel: string;
+  receiptNumber: string;
+  donorName: string;
+  donorEmail?: string | null;
+  donorAddress?: string | null;
+  amount: Decimal;
+  currency: string;
+  receivedAt: Date;
+  issuedAt: Date;
+  entryReference?: string | null;
+}
+
+export async function generateDonationReceiptPdf(details: DonationReceiptDetails): Promise<Uint8Array> {
+  const pdf = await PDFDocument.create();
+  pdf.setTitle(`Reçu fiscal ${details.receiptNumber}`);
+  pdf.setSubject('Reçu fiscal pour don');
+  pdf.setProducer('Association Management API');
+
+  const page = pdf.addPage([595.28, 841.89]);
+  const { width, height } = page.getSize();
+  const margin = 50;
+  let cursorY = height - margin;
+
+  const regularFont = await pdf.embedFont(StandardFonts.Helvetica);
+  const boldFont = await pdf.embedFont(StandardFonts.HelveticaBold);
+
+  page.drawText('Reçu fiscal de don', {
+    x: margin,
+    y: cursorY,
+    size: 24,
+    font: boldFont,
+  });
+  cursorY -= 36;
+
+  drawParagraph(page, regularFont, 12, margin, cursorY, width - margin * 2, [
+    `Association : ${details.organizationName}`,
+    `Identifiant : ${details.organizationId}`,
+    `Exercice : ${details.fiscalYearLabel}`,
+  ]);
+  cursorY -= 64;
+
+  cursorY = drawSection(page, boldFont, regularFont, cursorY, margin, width, 'Informations sur le donateur', [
+    ['Nom du donateur', details.donorName],
+    ['Adresse électronique', details.donorEmail ?? 'Non renseignée'],
+    ['Adresse postale', details.donorAddress ?? 'Non renseignée'],
+  ]);
+
+  const amountFormatter = new Intl.NumberFormat('fr-FR', {
+    style: 'currency',
+    currency: details.currency,
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+
+  const dateFormatter = new Intl.DateTimeFormat('fr-FR');
+  const amountText = amountFormatter.format(Number(details.amount.toFixed(2)));
+
+  cursorY = drawSection(page, boldFont, regularFont, cursorY - 12, margin, width, 'Détails du don', [
+    ['Numéro de reçu', details.receiptNumber],
+    ['Date de réception', dateFormatter.format(details.receivedAt)],
+    ['Date d\'émission', dateFormatter.format(details.issuedAt)],
+    ['Montant', amountText],
+    ['Référence d\'écriture', details.entryReference ?? 'Non renseignée'],
+  ]);
+
+  cursorY -= 24;
+  drawParagraph(
+    page,
+    regularFont,
+    11,
+    margin,
+    cursorY,
+    width - margin * 2,
+    [
+      'Ce reçu atteste que le don a été perçu conformément aux dispositions fiscales en vigueur.',
+      'Conservez ce document pour vos déclarations fiscales. Un contrôle peut nécessiter la présentation du reçu original.',
+    ]
+  );
+  cursorY -= 64;
+
+  drawParagraph(
+    page,
+    regularFont,
+    10,
+    margin,
+    cursorY,
+    width - margin * 2,
+    [
+      'Document généré par la plateforme comptable associative.',
+      'Signature électronique : non requise - reçu validé par hachage SHA-256 stocké en base.',
+    ]
+  );
+
+  return pdf.save();
+}
+
+function drawSection(
+  page: import('pdf-lib').PDFPage,
+  boldFont: import('pdf-lib').PDFFont,
+  regularFont: import('pdf-lib').PDFFont,
+  startY: number,
+  margin: number,
+  pageWidth: number,
+  title: string,
+  rows: [string, string][],
+): number {
+  let cursorY = startY;
+
+  page.drawText(title, {
+    x: margin,
+    y: cursorY,
+    size: 14,
+    font: boldFont,
+  });
+  cursorY -= 18;
+
+  const labelWidth = 160;
+  const lineHeight = 16;
+  const maxValueWidth = pageWidth - margin * 2 - labelWidth - 12;
+
+  for (const [label, rawValue] of rows) {
+    const lines = wrapText(rawValue, regularFont, 12, maxValueWidth);
+
+    page.drawText(`${label} :`, {
+      x: margin,
+      y: cursorY,
+      size: 12,
+      font: boldFont,
+    });
+
+    for (let index = 0; index < lines.length; index += 1) {
+      const value = lines[index];
+      page.drawText(value, {
+        x: margin + labelWidth,
+        y: cursorY,
+        size: 12,
+        font: regularFont,
+      });
+      cursorY -= lineHeight;
+    }
+    cursorY -= 4;
+  }
+
+  return cursorY;
+}
+
+function drawParagraph(
+  page: import('pdf-lib').PDFPage,
+  font: import('pdf-lib').PDFFont,
+  size: number,
+  x: number,
+  y: number,
+  width: number,
+  lines: string[],
+): void {
+  const lineHeight = size + 4;
+  let cursorY = y;
+
+  for (const line of lines) {
+    const wrapped = wrapText(line, font, size, width);
+    for (const segment of wrapped) {
+      page.drawText(segment, {
+        x,
+        y: cursorY,
+        size,
+        font,
+      });
+      cursorY -= lineHeight;
+    }
+  }
+}
+
+function wrapText(text: string, font: import('pdf-lib').PDFFont, size: number, maxWidth: number): string[] {
+  if (!text) {
+    return [''];
+  }
+
+  const words = text.split(/\s+/);
+  const lines: string[] = [];
+  let current = '';
+
+  for (const word of words) {
+    const candidate = current ? `${current} ${word}` : word;
+    const width = font.widthOfTextAtSize(candidate, size);
+
+    if (width <= maxWidth) {
+      current = candidate;
+    } else {
+      if (current) {
+        lines.push(current);
+      }
+      current = word;
+    }
+  }
+
+  if (current) {
+    lines.push(current);
+  }
+
+  return lines.length > 0 ? lines : [''];
+}

--- a/apps/api/src/modules/donations/schemas.ts
+++ b/apps/api/src/modules/donations/schemas.ts
@@ -1,0 +1,89 @@
+import { Prisma } from '@prisma/client';
+import { z } from 'zod';
+
+const decimalPattern = /^\d+(\.\d{1,2})?$/;
+
+const amountSchema = z
+  .union([z.string(), z.number()])
+  .transform((value, ctx) => {
+    const raw = typeof value === 'number' ? value.toString() : value;
+    const normalized = raw.trim();
+
+    if (normalized === '') {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Amount is required.',
+      });
+      return z.NEVER;
+    }
+
+    if (!decimalPattern.test(normalized)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Amount must have at most two decimal places.',
+      });
+      return z.NEVER;
+    }
+
+    try {
+      return new Prisma.Decimal(normalized);
+    } catch {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Amount is invalid.',
+      });
+      return z.NEVER;
+    }
+  })
+  .superRefine((decimal, ctx) => {
+    if (decimal.isNegative()) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Amount cannot be negative.',
+      });
+    }
+
+    if (decimal.decimalPlaces() > 2) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Amount must have at most two decimal places.',
+      });
+    }
+  });
+
+export const createDonationInputSchema = z.object({
+  entryId: z.string().uuid(),
+  amount: amountSchema,
+  currency: z
+    .string()
+    .trim()
+    .min(3, { message: 'Currency must have at least 3 characters.' })
+    .max(10, { message: 'Currency is too long.' })
+    .transform((value) => value.toUpperCase())
+    .optional(),
+  receivedAt: z.coerce.date(),
+  donor: z.object({
+    name: z.string().trim().min(1).max(255),
+    email: z
+      .string()
+      .trim()
+      .email({ message: 'Donor email must be valid.' })
+      .max(320)
+      .optional(),
+    address: z.string().trim().max(1024).optional(),
+  }),
+});
+
+export type CreateDonationInput = z.infer<typeof createDonationInputSchema>;
+
+export const listDonationsQuerySchema = z.object({
+  fiscalYearId: z.string().uuid().optional(),
+});
+
+export type ListDonationsQuery = z.infer<typeof listDonationsQuerySchema>;
+
+export const donationExportQuerySchema = z.object({
+  fiscalYearId: z.string().uuid(),
+});
+
+export type DonationExportQuery = z.infer<typeof donationExportQuerySchema>;

--- a/apps/api/src/modules/donations/service.ts
+++ b/apps/api/src/modules/donations/service.ts
@@ -1,0 +1,285 @@
+import { createHash } from 'node:crypto';
+import { Prisma, PrismaClient } from '@prisma/client';
+import { HttpProblemError } from '../../lib/problem-details';
+import type { ObjectStorage } from '../../plugins/object-storage';
+import {
+  createDonationInputSchema,
+  donationExportQuerySchema,
+  listDonationsQuerySchema,
+  type DonationExportQuery,
+  type ListDonationsQuery,
+} from './schemas';
+import { generateDonationReceiptPdf } from './pdf';
+
+export type DonationClient = PrismaClient | Prisma.TransactionClient;
+
+interface ListDonationsOptions {
+  pagination?: {
+    limit: number;
+    offset: number;
+  };
+}
+
+export async function createDonation(
+  client: DonationClient,
+  storage: ObjectStorage,
+  organizationId: string,
+  input: unknown
+) {
+  const parsed = createDonationInputSchema.parse(input);
+  const currency = parsed.currency ?? 'EUR';
+
+  const entry = await client.entry.findFirst({
+    where: { id: parsed.entryId, organizationId },
+    include: {
+      fiscalYear: true,
+      organization: true,
+    },
+  });
+
+  if (!entry || !entry.fiscalYear || !entry.organization) {
+    throw new HttpProblemError({
+      status: 404,
+      title: 'ENTRY_NOT_FOUND_FOR_DONATION',
+      detail: 'The specified accounting entry does not exist for this organization.',
+    });
+  }
+
+  const fiscalYear = entry.fiscalYear;
+  const organization = entry.organization;
+
+  if (parsed.receivedAt < fiscalYear.startDate || parsed.receivedAt > fiscalYear.endDate) {
+    throw new HttpProblemError({
+      status: 422,
+      title: 'DONATION_DATE_OUT_OF_RANGE',
+      detail: 'The donation date must fall within the selected fiscal year.',
+    });
+  }
+
+  const totals = await client.entryLine.aggregate({
+    where: { entryId: entry.id },
+    _sum: { debit: true },
+  });
+
+  const entryTotal = totals._sum.debit ?? new Prisma.Decimal(0);
+  if (!entryTotal.equals(parsed.amount)) {
+    throw new HttpProblemError({
+      status: 422,
+      title: 'DONATION_AMOUNT_MISMATCH',
+      detail: 'The donation amount must match the total amount of the linked entry.',
+    });
+  }
+
+  const receiptSequence = await reserveDonationReceiptNumber(client, {
+    organizationId,
+    fiscalYearId: fiscalYear.id,
+  });
+  const receiptNumber = formatReceiptNumber(fiscalYear.startDate, receiptSequence);
+  const issuedAt = new Date();
+
+  const pdfBytes = await generateDonationReceiptPdf({
+    organizationName: organization.name,
+    organizationId: organization.id,
+    fiscalYearLabel: fiscalYear.label,
+    receiptNumber,
+    donorName: parsed.donor.name,
+    donorEmail: parsed.donor.email,
+    donorAddress: parsed.donor.address,
+    amount: parsed.amount,
+    currency,
+    receivedAt: parsed.receivedAt,
+    issuedAt,
+    entryReference: entry.reference,
+  });
+
+  const pdfBuffer = Buffer.from(pdfBytes);
+  const receiptHash = createHash('sha256').update(pdfBuffer).digest('hex');
+
+  const storageKey = buildReceiptStorageKey(organizationId, fiscalYear.id, receiptNumber);
+  const { url: receiptUrl } = await storage.putObject({
+    key: storageKey,
+    body: pdfBuffer,
+    contentType: 'application/pdf',
+  });
+
+  try {
+    return await client.donation.create({
+      data: {
+        organizationId,
+        fiscalYearId: fiscalYear.id,
+        entryId: entry.id,
+        donorName: parsed.donor.name,
+        donorEmail: parsed.donor.email ?? null,
+        donorAddress: parsed.donor.address ?? null,
+        amount: parsed.amount,
+        currency,
+        receiptNumber,
+        receiptHash,
+        receiptUrl,
+        receivedAt: parsed.receivedAt,
+        issuedAt,
+      },
+    });
+  } catch (error) {
+    if (isUniqueViolation(error, 'donation_entry_id_key')) {
+      throw new HttpProblemError({
+        status: 409,
+        title: 'DONATION_ALREADY_EXISTS',
+        detail: 'A donation receipt has already been issued for this accounting entry.',
+      });
+    }
+
+    throw error;
+  }
+}
+
+export async function listDonations(
+  client: DonationClient,
+  organizationId: string,
+  query: ListDonationsQuery | undefined,
+  options: ListDonationsOptions = {}
+) {
+  const parsedQuery = listDonationsQuerySchema.parse(query ?? {});
+
+  const where: Prisma.DonationWhereInput = {
+    organizationId,
+  };
+
+  if (parsedQuery.fiscalYearId) {
+    where.fiscalYearId = parsedQuery.fiscalYearId;
+  }
+
+  const [items, total] = await Promise.all([
+    client.donation.findMany({
+      where,
+      orderBy: [
+        { receivedAt: 'desc' },
+        { receiptNumber: 'desc' },
+      ],
+      skip: options.pagination?.offset,
+      take: options.pagination?.limit,
+    }),
+    client.donation.count({ where }),
+  ]);
+
+  return { items, total };
+}
+
+export async function exportDonations(
+  client: DonationClient,
+  organizationId: string,
+  query: DonationExportQuery | undefined
+) {
+  const parsed = donationExportQuerySchema.parse(query ?? {});
+
+  const fiscalYear = await client.fiscalYear.findFirst({
+    where: { id: parsed.fiscalYearId, organizationId },
+  });
+
+  if (!fiscalYear) {
+    throw new HttpProblemError({
+      status: 404,
+      title: 'FISCAL_YEAR_NOT_FOUND',
+      detail: 'The requested fiscal year does not exist for this organization.',
+    });
+  }
+
+  const donations = await client.donation.findMany({
+    where: { organizationId, fiscalYearId: parsed.fiscalYearId },
+    orderBy: [
+      { receivedAt: 'asc' },
+      { receiptNumber: 'asc' },
+    ],
+  });
+
+  const header = [
+    'Receipt Number',
+    'Received At',
+    'Issued At',
+    'Donor Name',
+    'Donor Email',
+    'Donor Address',
+    'Amount',
+    'Currency',
+    'Receipt URL',
+    'Receipt Hash',
+  ].join(';');
+
+  const rows = donations.map((donation) =>
+    [
+      donation.receiptNumber,
+      formatDate(donation.receivedAt),
+      formatDate(donation.issuedAt),
+      donation.donorName,
+      donation.donorEmail ?? '',
+      donation.donorAddress?.replace(/\r?\n/g, ' ') ?? '',
+      donation.amount.toFixed(2),
+      donation.currency,
+      donation.receiptUrl,
+      donation.receiptHash,
+    ].join(';')
+  );
+
+  const csv = [header, ...rows].join('\n');
+
+  return { csv, fiscalYear };
+}
+
+function formatReceiptNumber(fiscalYearStart: Date, sequenceValue: number): string {
+  const year = fiscalYearStart.getUTCFullYear();
+  const padded = sequenceValue.toString().padStart(6, '0');
+  return `${year}-DON-${padded}`;
+}
+
+async function reserveDonationReceiptNumber(
+  client: DonationClient,
+  params: { organizationId: string; fiscalYearId: string }
+): Promise<number> {
+  const result = await client.$queryRaw<{ current_value: bigint | number }[]>(
+    Prisma.sql`
+      INSERT INTO "donation_receipt_sequence" ("organization_id", "fiscal_year_id", "next_value")
+      VALUES (${params.organizationId}::uuid, ${params.fiscalYearId}::uuid, 2)
+      ON CONFLICT ("organization_id", "fiscal_year_id")
+      DO UPDATE SET "next_value" = "donation_receipt_sequence"."next_value" + 1, "updated_at" = NOW()
+      RETURNING "next_value" - 1 AS current_value
+    `
+  );
+
+  const row = result[0];
+  if (!row) {
+    throw new HttpProblemError({
+      status: 500,
+      title: 'DONATION_SEQUENCE_RESERVATION_FAILED',
+      detail: 'Failed to reserve a receipt number for the donation.',
+    });
+  }
+
+  const currentValue = typeof row.current_value === 'bigint' ? Number(row.current_value) : Number(row.current_value);
+  if (!Number.isFinite(currentValue)) {
+    throw new HttpProblemError({
+      status: 500,
+      title: 'DONATION_SEQUENCE_RESERVATION_FAILED',
+      detail: 'Invalid receipt sequence generated for the donation.',
+    });
+  }
+
+  return currentValue;
+}
+
+function buildReceiptStorageKey(organizationId: string, fiscalYearId: string, receiptNumber: string): string {
+  const sanitizedNumber = receiptNumber.replace(/[^A-Za-z0-9_-]/g, '-');
+  return `donations/${organizationId}/${fiscalYearId}/${sanitizedNumber}.pdf`;
+}
+
+function formatDate(date: Date): string {
+  return date.toISOString().split('T')[0];
+}
+
+function isUniqueViolation(error: unknown, constraint: string): boolean {
+  return (
+    error instanceof Prisma.PrismaClientKnownRequestError &&
+    error.code === 'P2002' &&
+    Array.isArray(error.meta?.target) &&
+    (error.meta?.target as string[]).includes(constraint)
+  );
+}

--- a/apps/api/src/plugins/object-storage.ts
+++ b/apps/api/src/plugins/object-storage.ts
@@ -1,0 +1,93 @@
+import fp from 'fastify-plugin';
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import type { FastifyPluginAsync } from 'fastify';
+
+export interface PutObjectParams {
+  key: string;
+  body: Buffer;
+  contentType: string;
+}
+
+export interface PutObjectResult {
+  url: string;
+}
+
+export interface ObjectStorage {
+  putObject(params: PutObjectParams): Promise<PutObjectResult>;
+  getPublicUrl(key: string): string;
+}
+
+declare module 'fastify' {
+  interface FastifyInstance {
+    objectStorage: ObjectStorage;
+  }
+
+  interface FastifyRequest {
+    objectStorage: ObjectStorage;
+  }
+}
+
+const objectStoragePlugin: FastifyPluginAsync = fp(async (fastify) => {
+  const {
+    S3_ACCESS_KEY_ID,
+    S3_SECRET_ACCESS_KEY,
+    S3_BUCKET,
+    S3_REGION,
+    S3_ENDPOINT,
+    S3_PUBLIC_URL,
+  } = fastify.config;
+
+  const s3Client = new S3Client({
+    region: S3_REGION,
+    endpoint: S3_ENDPOINT || undefined,
+    forcePathStyle: Boolean(S3_ENDPOINT),
+    credentials: {
+      accessKeyId: S3_ACCESS_KEY_ID,
+      secretAccessKey: S3_SECRET_ACCESS_KEY,
+    },
+  });
+
+  const buildObjectUrl = (key: string): string => {
+    if (S3_PUBLIC_URL && S3_PUBLIC_URL.trim() !== '') {
+      return `${S3_PUBLIC_URL.replace(/\/?$/, '')}/${key}`;
+    }
+
+    if (S3_ENDPOINT && S3_ENDPOINT.trim() !== '') {
+      return `${S3_ENDPOINT.replace(/\/?$/, '')}/${S3_BUCKET}/${key}`;
+    }
+
+    return `https://${S3_BUCKET}.s3.${S3_REGION}.amazonaws.com/${key}`;
+  };
+
+  const storage: ObjectStorage = {
+    async putObject({ key, body, contentType }: PutObjectParams): Promise<PutObjectResult> {
+      await s3Client.send(
+        new PutObjectCommand({
+          Bucket: S3_BUCKET,
+          Key: key,
+          Body: body,
+          ContentType: contentType,
+        })
+      );
+
+      return { url: buildObjectUrl(key) };
+    },
+    getPublicUrl(key: string): string {
+      return buildObjectUrl(key);
+    },
+  };
+
+  fastify.decorate('objectStorage', storage);
+  fastify.decorateRequest('objectStorage', undefined as unknown as ObjectStorage);
+
+  fastify.addHook('onRequest', (request, _reply, done) => {
+    request.objectStorage = fastify.objectStorage;
+    done();
+  });
+
+  fastify.addHook('onClose', async () => {
+    s3Client.destroy();
+  });
+}, { name: 'object-storage' });
+
+export default objectStoragePlugin;

--- a/apps/api/src/routes/donations.ts
+++ b/apps/api/src/routes/donations.ts
@@ -1,0 +1,108 @@
+import type { FastifyPluginAsync } from 'fastify';
+import { z } from 'zod';
+import { UserRole } from '@prisma/client';
+import { HttpProblemError } from '../lib/problem-details';
+import {
+  createDonation,
+  exportDonations,
+  listDonations,
+  listDonationsQuerySchema,
+  donationExportQuerySchema,
+} from '../modules/donations';
+
+const organizationParamsSchema = z.object({
+  orgId: z.string().uuid(),
+});
+
+const donationsRoutes: FastifyPluginAsync = async (fastify) => {
+  const requireDonationManager = fastify.authorizeRoles(UserRole.TREASURER, UserRole.ADMIN);
+  const requireDonationViewer = fastify.authorizeRoles(
+    UserRole.TREASURER,
+    UserRole.ADMIN,
+    UserRole.SECRETARY,
+    UserRole.VIEWER
+  );
+
+  fastify.get(
+    '/orgs/:orgId/donations',
+    { preHandler: requireDonationViewer },
+    async (request) => {
+      const { orgId } = organizationParamsSchema.parse(request.params);
+      ensureOrganizationAccess(request.user?.organizationId, orgId);
+
+      const query = listDonationsQuerySchema.parse(request.query ?? {});
+      const pagination = request.pagination;
+
+      const result = await listDonations(request.prisma, orgId, query, {
+        pagination: pagination
+          ? {
+              limit: pagination.limit,
+              offset: pagination.offset,
+            }
+          : undefined,
+      });
+
+      const meta = pagination
+        ? {
+            total: result.total,
+            page: pagination.page,
+            limit: pagination.limit,
+          }
+        : { total: result.total };
+
+      return { data: result.items, meta };
+    }
+  );
+
+  fastify.post(
+    '/orgs/:orgId/donations',
+    { preHandler: requireDonationManager },
+    async (request, reply) => {
+      const { orgId } = organizationParamsSchema.parse(request.params);
+      ensureOrganizationAccess(request.user?.organizationId, orgId);
+
+      const donation = await createDonation(request.prisma, request.objectStorage, orgId, request.body);
+      reply.status(201).send({ data: donation });
+    }
+  );
+
+  fastify.get(
+    '/orgs/:orgId/donations/export',
+    { preHandler: requireDonationManager },
+    async (request, reply) => {
+      const { orgId } = organizationParamsSchema.parse(request.params);
+      ensureOrganizationAccess(request.user?.organizationId, orgId);
+
+      const query = donationExportQuerySchema.parse(request.query ?? {});
+      const report = await exportDonations(request.prisma, orgId, query);
+
+      reply
+        .type('text/csv; charset=utf-8')
+        .header(
+          'Content-Disposition',
+          `attachment; filename="donations-${report.fiscalYear.label}.csv"`
+        )
+        .send(report.csv);
+    }
+  );
+};
+
+function ensureOrganizationAccess(userOrgId: string | undefined, orgId: string): void {
+  if (!userOrgId) {
+    throw new HttpProblemError({
+      status: 401,
+      title: 'UNAUTHORIZED',
+      detail: 'Authentication is required.',
+    });
+  }
+
+  if (userOrgId !== orgId) {
+    throw new HttpProblemError({
+      status: 403,
+      title: 'FORBIDDEN_ORGANIZATION_ACCESS',
+      detail: 'You do not have access to this organization.',
+    });
+  }
+}
+
+export default donationsRoutes;

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -13,6 +13,7 @@ import prismaPlugin from './plugins/prisma';
 import problemJsonPlugin from './plugins/problem-json';
 import authPlugin from './plugins/auth';
 import memberReminderPlugin from './plugins/member-reminders';
+import objectStoragePlugin from './plugins/object-storage';
 
 dotenv.config();
 
@@ -39,6 +40,22 @@ const envSchema = z.object({
       z.string().url().optional()
     )
     .optional(),
+  S3_ACCESS_KEY_ID: z.string().default('local-access-key'),
+  S3_SECRET_ACCESS_KEY: z.string().default('local-secret-key'),
+  S3_REGION: z.string().default('us-east-1'),
+  S3_BUCKET: z.string().default('local-bucket'),
+  S3_ENDPOINT: z
+    .preprocess(
+      (value) => (typeof value === 'string' && value.trim() === '' ? undefined : value),
+      z.string().url().optional()
+    )
+    .optional(),
+  S3_PUBLIC_URL: z
+    .preprocess(
+      (value) => (typeof value === 'string' && value.trim() === '' ? undefined : value),
+      z.string().url().optional()
+    )
+    .optional(),
 });
 
 type RawEnvConfig = {
@@ -49,6 +66,12 @@ type RawEnvConfig = {
   JWT_REFRESH_SECRET?: string;
   REFRESH_TOKEN_TTL_DAYS?: number;
   REDIS_URL?: string;
+  S3_ACCESS_KEY_ID?: string;
+  S3_SECRET_ACCESS_KEY?: string;
+  S3_REGION?: string;
+  S3_BUCKET?: string;
+  S3_ENDPOINT?: string;
+  S3_PUBLIC_URL?: string;
 };
 
 export type AppConfig = z.infer<typeof envSchema>;
@@ -90,6 +113,12 @@ export async function buildServer(): Promise<FastifyInstance> {
         },
         REFRESH_TOKEN_TTL_DAYS: { type: 'number', default: 30 },
         REDIS_URL: { type: 'string', default: '' },
+        S3_ACCESS_KEY_ID: { type: 'string', default: 'local-access-key' },
+        S3_SECRET_ACCESS_KEY: { type: 'string', default: 'local-secret-key' },
+        S3_REGION: { type: 'string', default: 'us-east-1' },
+        S3_BUCKET: { type: 'string', default: 'local-bucket' },
+        S3_ENDPOINT: { type: 'string', default: '' },
+        S3_PUBLIC_URL: { type: 'string', default: '' },
       },
     },
   });
@@ -101,6 +130,7 @@ export async function buildServer(): Promise<FastifyInstance> {
   await app.register(authPlugin);
   await app.register(prismaPlugin);
   await app.register(memberReminderPlugin);
+  await app.register(objectStoragePlugin);
 
   await app.register(rateLimit, {
     max: 100,

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
       "name": "@asso/api",
       "version": "0.0.0",
       "dependencies": {
+        "@aws-sdk/client-s3": "3.895.0",
         "@fastify/autoload": "6.3.1",
         "@fastify/env": "5.0.2",
         "@fastify/rate-limit": "10.3.0",
@@ -68,6 +69,1103 @@
     "node_modules/@asso/web": {
       "resolved": "apps/web",
       "link": true
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-crypto/crc32c": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+      "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-crypto/sha1-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
+      "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.895.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.895.0.tgz",
+      "integrity": "sha512-iToLkPFLJOVr5Jx8An3ONIBxplsmjL5LU2F58ISMtXP68PWs195E1uHbDcmjeO5Fiby8lh0SHgPDs7Id28FvLg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.894.0",
+        "@aws-sdk/credential-provider-node": "3.895.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.893.0",
+        "@aws-sdk/middleware-expect-continue": "3.893.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.894.0",
+        "@aws-sdk/middleware-host-header": "3.893.0",
+        "@aws-sdk/middleware-location-constraint": "3.893.0",
+        "@aws-sdk/middleware-logger": "3.893.0",
+        "@aws-sdk/middleware-recursion-detection": "3.893.0",
+        "@aws-sdk/middleware-sdk-s3": "3.894.0",
+        "@aws-sdk/middleware-ssec": "3.893.0",
+        "@aws-sdk/middleware-user-agent": "3.895.0",
+        "@aws-sdk/region-config-resolver": "3.893.0",
+        "@aws-sdk/signature-v4-multi-region": "3.894.0",
+        "@aws-sdk/types": "3.893.0",
+        "@aws-sdk/util-endpoints": "3.895.0",
+        "@aws-sdk/util-user-agent-browser": "3.893.0",
+        "@aws-sdk/util-user-agent-node": "3.895.0",
+        "@aws-sdk/xml-builder": "3.894.0",
+        "@smithy/config-resolver": "^4.2.2",
+        "@smithy/core": "^3.11.1",
+        "@smithy/eventstream-serde-browser": "^4.1.1",
+        "@smithy/eventstream-serde-config-resolver": "^4.2.1",
+        "@smithy/eventstream-serde-node": "^4.1.1",
+        "@smithy/fetch-http-handler": "^5.2.1",
+        "@smithy/hash-blob-browser": "^4.1.1",
+        "@smithy/hash-node": "^4.1.1",
+        "@smithy/hash-stream-node": "^4.1.1",
+        "@smithy/invalid-dependency": "^4.1.1",
+        "@smithy/md5-js": "^4.1.1",
+        "@smithy/middleware-content-length": "^4.1.1",
+        "@smithy/middleware-endpoint": "^4.2.3",
+        "@smithy/middleware-retry": "^4.2.4",
+        "@smithy/middleware-serde": "^4.1.1",
+        "@smithy/middleware-stack": "^4.1.1",
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/node-http-handler": "^4.2.1",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/smithy-client": "^4.6.3",
+        "@smithy/types": "^4.5.0",
+        "@smithy/url-parser": "^4.1.1",
+        "@smithy/util-base64": "^4.1.0",
+        "@smithy/util-body-length-browser": "^4.1.0",
+        "@smithy/util-body-length-node": "^4.1.0",
+        "@smithy/util-defaults-mode-browser": "^4.1.3",
+        "@smithy/util-defaults-mode-node": "^4.1.3",
+        "@smithy/util-endpoints": "^3.1.2",
+        "@smithy/util-middleware": "^4.1.1",
+        "@smithy/util-retry": "^4.1.2",
+        "@smithy/util-stream": "^4.3.2",
+        "@smithy/util-utf8": "^4.1.0",
+        "@smithy/util-waiter": "^4.1.1",
+        "@types/uuid": "^9.0.1",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.895.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.895.0.tgz",
+      "integrity": "sha512-AQHk6iJrwce/NwZa5/Njy0ZGoHdxWCajkgufhXk53L0kRiC3vUPPWEV1m1F3etQWhaUsatcO2xtRuKvLpe4zgA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.894.0",
+        "@aws-sdk/middleware-host-header": "3.893.0",
+        "@aws-sdk/middleware-logger": "3.893.0",
+        "@aws-sdk/middleware-recursion-detection": "3.893.0",
+        "@aws-sdk/middleware-user-agent": "3.895.0",
+        "@aws-sdk/region-config-resolver": "3.893.0",
+        "@aws-sdk/types": "3.893.0",
+        "@aws-sdk/util-endpoints": "3.895.0",
+        "@aws-sdk/util-user-agent-browser": "3.893.0",
+        "@aws-sdk/util-user-agent-node": "3.895.0",
+        "@smithy/config-resolver": "^4.2.2",
+        "@smithy/core": "^3.11.1",
+        "@smithy/fetch-http-handler": "^5.2.1",
+        "@smithy/hash-node": "^4.1.1",
+        "@smithy/invalid-dependency": "^4.1.1",
+        "@smithy/middleware-content-length": "^4.1.1",
+        "@smithy/middleware-endpoint": "^4.2.3",
+        "@smithy/middleware-retry": "^4.2.4",
+        "@smithy/middleware-serde": "^4.1.1",
+        "@smithy/middleware-stack": "^4.1.1",
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/node-http-handler": "^4.2.1",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/smithy-client": "^4.6.3",
+        "@smithy/types": "^4.5.0",
+        "@smithy/url-parser": "^4.1.1",
+        "@smithy/util-base64": "^4.1.0",
+        "@smithy/util-body-length-browser": "^4.1.0",
+        "@smithy/util-body-length-node": "^4.1.0",
+        "@smithy/util-defaults-mode-browser": "^4.1.3",
+        "@smithy/util-defaults-mode-node": "^4.1.3",
+        "@smithy/util-endpoints": "^3.1.2",
+        "@smithy/util-middleware": "^4.1.1",
+        "@smithy/util-retry": "^4.1.2",
+        "@smithy/util-utf8": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.894.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.894.0.tgz",
+      "integrity": "sha512-7zbO31NV2FaocmMtWOg/fuTk3PC2Ji2AC0Fi2KqrppEDIcwLlTTuT9w/rdu/93Pz+wyUhCxWnDc0tPbwtCLs+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.893.0",
+        "@aws-sdk/xml-builder": "3.894.0",
+        "@smithy/core": "^3.11.1",
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/signature-v4": "^5.2.1",
+        "@smithy/smithy-client": "^4.6.3",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-base64": "^4.1.0",
+        "@smithy/util-body-length-browser": "^4.1.0",
+        "@smithy/util-middleware": "^4.1.1",
+        "@smithy/util-utf8": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.894.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.894.0.tgz",
+      "integrity": "sha512-2aiQJIRWOuROPPISKgzQnH/HqSfucdk5z5VMemVH3Mm2EYOrzBwmmiiFpmSMN3ST+sE8c7gusqycUchP+KfALQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.894.0",
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.894.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.894.0.tgz",
+      "integrity": "sha512-Z5QQpqFRflszrT+lUq6+ORuu4jRDcpgCUSoTtlhczidMqfdOSckKmK3chZEfmUUJPSwoFQZ7EiVTsX3c886fBg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.894.0",
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/fetch-http-handler": "^5.2.1",
+        "@smithy/node-http-handler": "^4.2.1",
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/smithy-client": "^4.6.3",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-stream": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.895.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.895.0.tgz",
+      "integrity": "sha512-uIh7N4IN/yIk+qYMAkVpVkjhB90SGKSfaXEVcnmxzBDG6e5304HKT0esqoCVZvtFfLKasjm2TOpalM5l3fi/dA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.894.0",
+        "@aws-sdk/credential-provider-env": "3.894.0",
+        "@aws-sdk/credential-provider-http": "3.894.0",
+        "@aws-sdk/credential-provider-process": "3.894.0",
+        "@aws-sdk/credential-provider-sso": "3.895.0",
+        "@aws-sdk/credential-provider-web-identity": "3.895.0",
+        "@aws-sdk/nested-clients": "3.895.0",
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/credential-provider-imds": "^4.1.2",
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/shared-ini-file-loader": "^4.2.0",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.895.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.895.0.tgz",
+      "integrity": "sha512-7xsBCmkBUz+2sNqNsDJ1uyQsBvwhNFzwFt8wX39WrFJTpTQh3uNQ5g8QH21BbkKqIFKCLdvgHgwt3Ub5RGVuPA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.894.0",
+        "@aws-sdk/credential-provider-http": "3.894.0",
+        "@aws-sdk/credential-provider-ini": "3.895.0",
+        "@aws-sdk/credential-provider-process": "3.894.0",
+        "@aws-sdk/credential-provider-sso": "3.895.0",
+        "@aws-sdk/credential-provider-web-identity": "3.895.0",
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/credential-provider-imds": "^4.1.2",
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/shared-ini-file-loader": "^4.2.0",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.894.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.894.0.tgz",
+      "integrity": "sha512-VU74GNsj+SsO+pl4d+JimlQ7+AcderZaC6bFndQssQdFZ5NRad8yFNz5Xbec8CPJr+z/VAwHib6431F5nYF46g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.894.0",
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/shared-ini-file-loader": "^4.2.0",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.895.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.895.0.tgz",
+      "integrity": "sha512-bZCcHUZGz+XlCaK0KEOHGHkMtlwIvnpxJvlZtSCVaBdX/IgouxaB42fxChflxSMRWF45ygdezfky4i17f6vC4w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.895.0",
+        "@aws-sdk/core": "3.894.0",
+        "@aws-sdk/token-providers": "3.895.0",
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/shared-ini-file-loader": "^4.2.0",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.895.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.895.0.tgz",
+      "integrity": "sha512-tKbXbOp2xrL02fxKvB7ko1E4Uvyy5TF9qi5pT2MVWNnfSsBlUM80aJ6tyUPKWXdUTdAlPrU3XcwgQl/DnnRa9A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.894.0",
+        "@aws-sdk/nested-clients": "3.895.0",
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/shared-ini-file-loader": "^4.2.0",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.893.0.tgz",
+      "integrity": "sha512-H+wMAoFC73T7M54OFIezdHXR9/lH8TZ3Cx1C3MEBb2ctlzQrVCd8LX8zmOtcGYC8plrRwV+8rNPe0FMqecLRew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.893.0",
+        "@aws-sdk/util-arn-parser": "3.893.0",
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-config-provider": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.893.0.tgz",
+      "integrity": "sha512-PEZkvD6k0X9sacHkvkVF4t2QyQEAzd35OJ2bIrjWCfc862TwukMMJ1KErRmQ1WqKXHKF4L0ed5vtWaO/8jVLNA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.894.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.894.0.tgz",
+      "integrity": "sha512-Dcz3thFO+9ZvTXV+Q4v/2okfMY8sUCHHBqJMUf9BDEuSvV94JVXFXbu1rm6S/N1Rh0gMLoUVzrOk3W84BLGPsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-crypto/util": "5.2.0",
+        "@aws-sdk/core": "3.894.0",
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/is-array-buffer": "^4.1.0",
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-middleware": "^4.1.1",
+        "@smithy/util-stream": "^4.3.2",
+        "@smithy/util-utf8": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.893.0.tgz",
+      "integrity": "sha512-qL5xYRt80ahDfj9nDYLhpCNkDinEXvjLe/Qen/Y/u12+djrR2MB4DRa6mzBCkLkdXDtf0WAoW2EZsNCfGrmOEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.893.0.tgz",
+      "integrity": "sha512-MlbBc7Ttb1ekbeeeFBU4DeEZOLb5s0Vl4IokvO17g6yJdLk4dnvZro9zdXl3e7NXK+kFxHRBFZe55p/42mVgDA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.893.0.tgz",
+      "integrity": "sha512-ZqzMecjju5zkBquSIfVfCORI/3Mge21nUY4nWaGQy+NUXehqCGG4W7AiVpiHGOcY2cGJa7xeEkYcr2E2U9U0AA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.893.0.tgz",
+      "integrity": "sha512-H7Zotd9zUHQAr/wr3bcWHULYhEeoQrF54artgsoUGIf/9emv6LzY89QUccKIxYd6oHKNTrTyXm9F0ZZrzXNxlg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.893.0",
+        "@aws/lambda-invoke-store": "^0.0.1",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.894.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.894.0.tgz",
+      "integrity": "sha512-0C3lTVdTuv5CkJ4LulpA7FmGFSKrGUKxnFZ6+qGjYjNzbdiHXfq0TyEBiDmVqDkoV2k4AT2H/m0Xw//rTkcNEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.894.0",
+        "@aws-sdk/types": "3.893.0",
+        "@aws-sdk/util-arn-parser": "3.893.0",
+        "@smithy/core": "^3.11.1",
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/signature-v4": "^5.2.1",
+        "@smithy/smithy-client": "^4.6.3",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-config-provider": "^4.1.0",
+        "@smithy/util-middleware": "^4.1.1",
+        "@smithy/util-stream": "^4.3.2",
+        "@smithy/util-utf8": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/middleware-ssec": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.893.0.tgz",
+      "integrity": "sha512-e4ccCiAnczv9mMPheKjgKxZQN473mcup+3DPLVNnIw5GRbQoDqPSB70nUzfORKZvM7ar7xLMPxNR8qQgo1C8Rg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-ssec/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.895.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.895.0.tgz",
+      "integrity": "sha512-JUqQW2RPp4I95wZ/Im9fTiaX3DF55oJgeoiNlLdHkQZPSNNS/pT1WMWMReSvJdcfSNU3xSUaLtI+h4mQjQUDbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.894.0",
+        "@aws-sdk/types": "3.893.0",
+        "@aws-sdk/util-endpoints": "3.895.0",
+        "@smithy/core": "^3.11.1",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.895.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.895.0.tgz",
+      "integrity": "sha512-8w1ihfYgvds6kfal/qJXQQrHRsKYh2nujSyzWMo2TMKMze9WPZA93G4mRbRtKtbSuQ66mVWePH8Cksq35ABu2Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.894.0",
+        "@aws-sdk/middleware-host-header": "3.893.0",
+        "@aws-sdk/middleware-logger": "3.893.0",
+        "@aws-sdk/middleware-recursion-detection": "3.893.0",
+        "@aws-sdk/middleware-user-agent": "3.895.0",
+        "@aws-sdk/region-config-resolver": "3.893.0",
+        "@aws-sdk/types": "3.893.0",
+        "@aws-sdk/util-endpoints": "3.895.0",
+        "@aws-sdk/util-user-agent-browser": "3.893.0",
+        "@aws-sdk/util-user-agent-node": "3.895.0",
+        "@smithy/config-resolver": "^4.2.2",
+        "@smithy/core": "^3.11.1",
+        "@smithy/fetch-http-handler": "^5.2.1",
+        "@smithy/hash-node": "^4.1.1",
+        "@smithy/invalid-dependency": "^4.1.1",
+        "@smithy/middleware-content-length": "^4.1.1",
+        "@smithy/middleware-endpoint": "^4.2.3",
+        "@smithy/middleware-retry": "^4.2.4",
+        "@smithy/middleware-serde": "^4.1.1",
+        "@smithy/middleware-stack": "^4.1.1",
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/node-http-handler": "^4.2.1",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/smithy-client": "^4.6.3",
+        "@smithy/types": "^4.5.0",
+        "@smithy/url-parser": "^4.1.1",
+        "@smithy/util-base64": "^4.1.0",
+        "@smithy/util-body-length-browser": "^4.1.0",
+        "@smithy/util-body-length-node": "^4.1.0",
+        "@smithy/util-defaults-mode-browser": "^4.1.3",
+        "@smithy/util-defaults-mode-node": "^4.1.3",
+        "@smithy/util-endpoints": "^3.1.2",
+        "@smithy/util-middleware": "^4.1.1",
+        "@smithy/util-retry": "^4.1.2",
+        "@smithy/util-utf8": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.893.0.tgz",
+      "integrity": "sha512-/cJvh3Zsa+Of0Zbg7vl9wp/kZtdb40yk/2+XcroAMVPO9hPvmS9r/UOm6tO7FeX4TtkRFwWaQJiTZTgSdsPY+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-config-provider": "^4.1.0",
+        "@smithy/util-middleware": "^4.1.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.894.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.894.0.tgz",
+      "integrity": "sha512-Te5b3fSbatkZrh3eYNmpOadZFKsCLNSwiolQKQeEeKHxdnqORwYXa+0ypcTHle6ukic+tFRRd9n3NuMVo9uiVg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "3.894.0",
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/signature-v4": "^5.2.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.895.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.895.0.tgz",
+      "integrity": "sha512-vJqrEHFFGRZ3ok5T+jII00sa2DQ3HdVkTBIfM0DcrcPssqDV18VKdA767qiBdIEN/cygjdBg8Ri/cuq6ER9BeQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.894.0",
+        "@aws-sdk/nested-clients": "3.895.0",
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/shared-ini-file-loader": "^4.2.0",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.893.0.tgz",
+      "integrity": "sha512-Aht1nn5SnA0N+Tjv0dzhAY7CQbxVtmq1bBR6xI0MhG7p2XYVh1wXuKTzrldEvQWwA3odOYunAfT9aBiKZx9qIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.893.0.tgz",
+      "integrity": "sha512-u8H4f2Zsi19DGnwj5FSZzDMhytYF/bCh37vAtBsn3cNDL3YG578X5oc+wSX54pM3tOxS+NY7tvOAo52SW7koUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-arn-parser/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.895.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.895.0.tgz",
+      "integrity": "sha512-MhxBvWbwxmKknuggO2NeMwOVkHOYL98pZ+1ZRI5YwckoCL3AvISMnPJgfN60ww6AIXHGpkp+HhpFdKOe8RHSEg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/types": "^4.5.0",
+        "@smithy/url-parser": "^4.1.1",
+        "@smithy/util-endpoints": "^3.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.893.0.tgz",
+      "integrity": "sha512-T89pFfgat6c8nMmpI8eKjBcDcgJq36+m9oiXbcUzeU55MP9ZuGgBomGjGnHaEyF36jenW9gmg3NfZDm0AO2XPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.893.0.tgz",
+      "integrity": "sha512-PE9NtbDBW6Kgl1bG6A5fF3EPo168tnkj8TgMcT0sg4xYBWsBpq0bpJZRh+Jm5Bkwiw9IgTCLjEU7mR6xWaMB9w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/types": "^4.5.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.895.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.895.0.tgz",
+      "integrity": "sha512-lLRC7BAFOPtJk4cZC0Q0MZBMCGF109QpGnug3L3n/2TJW02Sinz9lzA0ykBpYXe9j60LjIYSENCg+F4DZE5vxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.895.0",
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.894.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.894.0.tgz",
+      "integrity": "sha512-E6EAMc9dT1a2DOdo4zyOf3fp5+NJ2wI+mcm7RaW1baFIWDwcb99PpvWoV7YEiK7oaBDshuOEGWKUSYXdW+JYgA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "fast-xml-parser": "5.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.0.1.tgz",
+      "integrity": "sha512-ORHRQ2tmvnBXc8t/X9Z8IcSbBA4xTLKuN873FopzklHMeqBst7YG0d+AX97inkvDX+NChYtSr+qGfcqGFaI8Zw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -1482,6 +2580,1038 @@
         "win32"
       ]
     },
+    "node_modules/@smithy/abort-controller": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.1.1.tgz",
+      "integrity": "sha512-vkzula+IwRvPR6oKQhMYioM3A/oX/lFCZiwuxkQbRhqJS2S4YRY2k7k/SyR2jMf3607HLtbEwlRxi0ndXHMjRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/abort-controller/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/chunked-blob-reader": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-5.1.0.tgz",
+      "integrity": "sha512-a36AtR7Q7XOhRPt6F/7HENmTWcB8kN7mDJcOFM/+FuKO6x88w8MQJfYCufMWh4fGyVkPjUh3Rrz/dnqFQdo6OQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/chunked-blob-reader-native": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-4.1.0.tgz",
+      "integrity": "sha512-Bnv0B3nSlfB2mPO0WgM49I/prl7+kamF042rrf3ezJ3Z4C7csPYvyYgZfXTGXwXfj1mAwDWjE/ybIf49PzFzvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-base64": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/chunked-blob-reader-native/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/chunked-blob-reader/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.2.2.tgz",
+      "integrity": "sha512-IT6MatgBWagLybZl1xQcURXRICvqz1z3APSCAI9IqdvfCkrA7RaQIEfgC6G/KvfxnDfQUDqFV+ZlixcuFznGBQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-config-provider": "^4.1.0",
+        "@smithy/util-middleware": "^4.1.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/config-resolver/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.12.0.tgz",
+      "integrity": "sha512-zJeAgogZfbwlPGL93y4Z/XNeIN37YCreRUd6YMIRvaq+6RnBK8PPYYIQ85Is/GglPh3kNImD5riDCXbVSDpCiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-serde": "^4.1.1",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-base64": "^4.1.0",
+        "@smithy/util-body-length-browser": "^4.1.0",
+        "@smithy/util-middleware": "^4.1.1",
+        "@smithy/util-stream": "^4.3.2",
+        "@smithy/util-utf8": "^4.1.0",
+        "@smithy/uuid": "^1.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.1.2.tgz",
+      "integrity": "sha512-JlYNq8TShnqCLg0h+afqe2wLAwZpuoSgOyzhYvTgbiKBWRov+uUve+vrZEQO6lkdLOWPh7gK5dtb9dS+KGendg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/types": "^4.5.0",
+        "@smithy/url-parser": "^4.1.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.1.1.tgz",
+      "integrity": "sha512-PwkQw1hZwHTQB6X5hSUWz2OSeuj5Z6enWuAqke7DgWoP3t6vg3ktPpqPz3Erkn6w+tmsl8Oss6nrgyezoea2Iw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-hex-encoding": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/eventstream-serde-browser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.1.1.tgz",
+      "integrity": "sha512-Q9QWdAzRaIuVkefupRPRFAasaG/droBqn1feiMnmLa+LLEUG45pqX1+FurHFmlqiCfobB3nUlgoJfeXZsr7MPA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.1.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-browser/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/eventstream-serde-config-resolver": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.2.1.tgz",
+      "integrity": "sha512-oSUkF9zDN9zcOUBMtxp8RewJlh71E9NoHWU8jE3hU9JMYCsmW4assVTpgic/iS3/dM317j6hO5x18cc3XrfvEw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-config-resolver/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/eventstream-serde-node": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.1.1.tgz",
+      "integrity": "sha512-tn6vulwf/ScY0vjhzptSJuDJJqlhNtUjkxJ4wiv9E3SPoEqTEKbaq6bfqRO7nvhTG29ALICRcvfFheOUPl8KNA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.1.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-node/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/eventstream-serde-universal": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.1.1.tgz",
+      "integrity": "sha512-uLOAiM/Dmgh2CbEXQx+6/ssK7fbzFhd+LjdyFxXid5ZBCbLHTFHLdD/QbXw5aEDsLxQhgzDxLLsZhsftAYwHJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-codec": "^4.1.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-universal/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.2.1.tgz",
+      "integrity": "sha512-5/3wxKNtV3wO/hk1is+CZUhL8a1yy/U+9u9LKQ9kZTkMsHaQjJhc3stFfiujtMnkITjzWfndGA2f7g9Uh9vKng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/querystring-builder": "^4.1.1",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-base64": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/hash-blob-browser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.1.1.tgz",
+      "integrity": "sha512-avAtk++s1e/1VODf+rg7c9R2pB5G9y8yaJaGY4lPZI2+UIqVyuSDMikWjeWfBVmFZ3O7NpDxBbUCyGhThVUKWQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/chunked-blob-reader": "^5.1.0",
+        "@smithy/chunked-blob-reader-native": "^4.1.0",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-blob-browser/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.1.1.tgz",
+      "integrity": "sha512-H9DIU9WBLhYrvPs9v4sYvnZ1PiAI0oc8CgNQUJ1rpN3pP7QADbTOUjchI2FB764Ub0DstH5xbTqcMJu1pnVqxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-buffer-from": "^4.1.0",
+        "@smithy/util-utf8": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/hash-stream-node": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.1.1.tgz",
+      "integrity": "sha512-3ztT4pV0Moazs3JAYFdfKk11kYFDo4b/3R3+xVjIm6wY9YpJf+xfz+ocEnNKcWAdcmSMqi168i2EMaKmJHbJMA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-utf8": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-stream-node/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.1.1.tgz",
+      "integrity": "sha512-1AqLyFlfrrDkyES8uhINRlJXmHA2FkG+3DY8X+rmLSqmFwk3DJnvhyGzyByPyewh2jbmV+TYQBEfngQax8IFGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.1.0.tgz",
+      "integrity": "sha512-ePTYUOV54wMogio+he4pBybe8fwg4sDvEVDBU8ZlHOZXbXK3/C0XfJgUCu6qAZcawv05ZhZzODGUerFBPsPUDQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/md5-js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.1.1.tgz",
+      "integrity": "sha512-MvWXKK743BuHjr/hnWuT6uStdKEaoqxHAQUvbKJPPZM5ZojTNFI5D+47BoQfBE5RgGlRRty05EbWA+NXDv+hIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-utf8": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/md5-js/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.1.1.tgz",
+      "integrity": "sha512-9wlfBBgTsRvC2JxLJxv4xDGNBrZuio3AgSl0lSFX7fneW2cGskXTYpFxCdRYD2+5yzmsiTuaAJD1Wp7gWt9y9w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.2.4.tgz",
+      "integrity": "sha512-FZ4hzupOmthm8Q8ujYrd0I+/MHwVMuSTdkDtIQE0xVuvJt9pLT6Q+b0p4/t+slDyrpcf+Wj7SN+ZqT5OryaaZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.12.0",
+        "@smithy/middleware-serde": "^4.1.1",
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/shared-ini-file-loader": "^4.2.0",
+        "@smithy/types": "^4.5.0",
+        "@smithy/url-parser": "^4.1.1",
+        "@smithy/util-middleware": "^4.1.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.3.0.tgz",
+      "integrity": "sha512-qhEX9745fAxZvtLM4bQJAVC98elWjiMO2OiHl1s6p7hUzS4QfZO1gXUYNwEK8m0J6NoCD5W52ggWxbIDHI0XSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/service-error-classification": "^4.1.2",
+        "@smithy/smithy-client": "^4.6.4",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-middleware": "^4.1.1",
+        "@smithy/util-retry": "^4.1.2",
+        "@smithy/uuid": "^1.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.1.1.tgz",
+      "integrity": "sha512-lh48uQdbCoj619kRouev5XbWhCwRKLmphAif16c4J6JgJ4uXjub1PI6RL38d3BLliUvSso6klyB/LTNpWSNIyg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.1.1.tgz",
+      "integrity": "sha512-ygRnniqNcDhHzs6QAPIdia26M7e7z9gpkIMUe/pK0RsrQ7i5MblwxY8078/QCnGq6AmlUUWgljK2HlelsKIb/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.2.2.tgz",
+      "integrity": "sha512-SYGTKyPvyCfEzIN5rD8q/bYaOPZprYUPD2f5g9M7OjaYupWOoQFYJ5ho+0wvxIRf471i2SR4GoiZ2r94Jq9h6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/shared-ini-file-loader": "^4.2.0",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.2.1.tgz",
+      "integrity": "sha512-REyybygHlxo3TJICPF89N2pMQSf+p+tBJqpVe1+77Cfi9HBPReNjTgtZ1Vg73exq24vkqJskKDpfF74reXjxfw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.1.1",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/querystring-builder": "^4.1.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.1.1.tgz",
+      "integrity": "sha512-gm3ZS7DHxUbzC2wr8MUCsAabyiXY0gaj3ROWnhSx/9sPMc6eYLMM4rX81w1zsMaObj2Lq3PZtNCC1J6lpEY7zg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.2.1.tgz",
+      "integrity": "sha512-T8SlkLYCwfT/6m33SIU/JOVGNwoelkrvGjFKDSDtVvAXj/9gOT78JVJEas5a+ETjOu4SVvpCstKgd0PxSu/aHw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.1.1.tgz",
+      "integrity": "sha512-J9b55bfimP4z/Jg1gNo+AT84hr90p716/nvxDkPGCD4W70MPms0h8KF50RDRgBGZeL83/u59DWNqJv6tEP/DHA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-uri-escape": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.1.1.tgz",
+      "integrity": "sha512-63TEp92YFz0oQ7Pj9IuI3IgnprP92LrZtRAkE3c6wLWJxfy/yOPRt39IOKerVr0JS770olzl0kGafXlAXZ1vng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.1.2.tgz",
+      "integrity": "sha512-Kqd8wyfmBWHZNppZSMfrQFpc3M9Y/kjyN8n8P4DqJJtuwgK1H914R471HTw7+RL+T7+kI1f1gOnL7Vb5z9+NgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.2.0.tgz",
+      "integrity": "sha512-OQTfmIEp2LLuWdxa8nEEPhZmiOREO6bcB6pjs0AySf4yiZhl6kMOfqmcwcY8BaBPX+0Tb+tG7/Ia/6mwpoZ7Pw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.2.1.tgz",
+      "integrity": "sha512-M9rZhWQLjlQVCCR37cSjHfhriGRN+FQ8UfgrYNufv66TJgk+acaggShl3KS5U/ssxivvZLlnj7QH2CUOKlxPyA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.1.0",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-hex-encoding": "^4.1.0",
+        "@smithy/util-middleware": "^4.1.1",
+        "@smithy/util-uri-escape": "^4.1.0",
+        "@smithy/util-utf8": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.6.4.tgz",
+      "integrity": "sha512-qL7O3VDyfzCSN9r+sdbQXGhaHtrfSJL30En6Jboj0I3bobf2g1/T0eP2L4qxqrEW26gWhJ4THI4ElVVLjYyBHg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.12.0",
+        "@smithy/middleware-endpoint": "^4.2.4",
+        "@smithy/middleware-stack": "^4.1.1",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-stream": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.5.0.tgz",
+      "integrity": "sha512-RkUpIOsVlAwUIZXO1dsz8Zm+N72LClFfsNqf173catVlvRZiwPy0x2u0JLEA4byreOPKDZPGjmPDylMoP8ZJRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.1.1.tgz",
+      "integrity": "sha512-bx32FUpkhcaKlEoOMbScvc93isaSiRM75pQ5IgIBaMkT7qMlIibpPRONyx/0CvrXHzJLpOn/u6YiDX2hcvs7Dg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^4.1.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.1.0.tgz",
+      "integrity": "sha512-RUGd4wNb8GeW7xk+AY5ghGnIwM96V0l2uzvs/uVHf+tIuVX2WSvynk5CxNoBCsM2rQRSZElAo9rt3G5mJ/gktQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.1.0",
+        "@smithy/util-utf8": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.1.0.tgz",
+      "integrity": "sha512-V2E2Iez+bo6bUMOTENPr6eEmepdY8Hbs+Uc1vkDKgKNA/brTJqOW/ai3JO1BGj9GbCeLqw90pbbH7HFQyFotGQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.1.0.tgz",
+      "integrity": "sha512-BOI5dYjheZdgR9XiEM3HJcEMCXSoqbzu7CzIgYrx0UtmvtC3tC2iDGpJLsSRFffUpy8ymsg2ARMP5fR8mtuUQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.1.0.tgz",
+      "integrity": "sha512-N6yXcjfe/E+xKEccWEKzK6M+crMrlwaCepKja0pNnlSkm6SjAeLKKA++er5Ba0I17gvKfN/ThV+ZOx/CntKTVw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.1.0.tgz",
+      "integrity": "sha512-swXz2vMjrP1ZusZWVTB/ai5gK+J8U0BWvP10v9fpcFvg+Xi/87LHvHfst2IgCs1i0v4qFZfGwCmeD/KNCdJZbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.1.4.tgz",
+      "integrity": "sha512-mLDJ1s4eA3vwOGaQOEPlg5LB4LdZUUMpB5UMOMofeGhWqiS7WR7dTpLiNi9zVn+YziKUd3Af5NLfxDs7NJqmIw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/smithy-client": "^4.6.4",
+        "@smithy/types": "^4.5.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.1.4.tgz",
+      "integrity": "sha512-pjX2iMTcOASaSanAd7bu6i3fcMMezr3NTr8Rh64etB0uHRZi+Aw86DoCxPESjY4UTIuA06hhqtTtw95o//imYA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^4.2.2",
+        "@smithy/credential-provider-imds": "^4.1.2",
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/smithy-client": "^4.6.4",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.1.2.tgz",
+      "integrity": "sha512-+AJsaaEGb5ySvf1SKMRrPZdYHRYSzMkCoK16jWnIMpREAnflVspMIDeCVSZJuj+5muZfgGpNpijE3mUNtjv01Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.1.0.tgz",
+      "integrity": "sha512-1LcueNN5GYC4tr8mo14yVYbh/Ur8jHhWOxniZXii+1+ePiIbsLZ5fEI0QQGtbRRP5mOhmooos+rLmVASGGoq5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.1.1.tgz",
+      "integrity": "sha512-CGmZ72mL29VMfESz7S6dekqzCh8ZISj3B+w0g1hZFXaOjGTVaSqfAEFAq8EGp8fUL+Q2l8aqNmt8U1tglTikeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.1.2.tgz",
+      "integrity": "sha512-NCgr1d0/EdeP6U5PSZ9Uv5SMR5XRRYoVr1kRVtKZxWL3tixEL3UatrPIMFZSKwHlCcp2zPLDvMubVDULRqeunA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^4.1.2",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.3.2.tgz",
+      "integrity": "sha512-Ka+FA2UCC/Q1dEqUanCdpqwxOFdf5Dg2VXtPtB1qxLcSGh5C1HdzklIt18xL504Wiy9nNUKwDMRTVCbKGoK69g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^5.2.1",
+        "@smithy/node-http-handler": "^4.2.1",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-base64": "^4.1.0",
+        "@smithy/util-buffer-from": "^4.1.0",
+        "@smithy/util-hex-encoding": "^4.1.0",
+        "@smithy/util-utf8": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.1.0.tgz",
+      "integrity": "sha512-b0EFQkq35K5NHUYxU72JuoheM6+pytEVUGlTwiFxWFpmddA+Bpz3LgsPRIpBk8lnPE47yT7AF2Egc3jVnKLuPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.1.0.tgz",
+      "integrity": "sha512-mEu1/UIXAdNYuBcyEPbjScKi/+MQVXNIuY/7Cm5XLIWe319kDrT5SizBE95jqtmEXoDbGoZxKLCMttdZdqTZKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/util-waiter": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.1.1.tgz",
+      "integrity": "sha512-PJBmyayrlfxM7nbqjomF4YcT1sApQwZio0NHSsT0EzhJqljRmvhzqZua43TyEs80nJk2Cn2FGPg/N8phH6KeCQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.1.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-waiter/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/uuid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.0.0.tgz",
+      "integrity": "sha512-OlA/yZHh0ekYFnbUkmYBDQPE6fGfdrvgz39ktp8Xf+FA6BfxLejPTMDOG0Nfk5/rDySAz1dRbFf24zaAFYVXlQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/uuid/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
@@ -1668,6 +3798,12 @@
       "dependencies": {
         "@types/superagent": "*"
       }
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.44.0",
@@ -2319,6 +4455,12 @@
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/bowser": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.12.1.tgz",
+      "integrity": "sha512-z4rE2Gxh7tvshQ4hluIT7XcFrgLIQaw9X3A+kTTRdovCz5PMukm/0QC/BKSYPj3omF5Qfypn9O/c5kgpmvYUCw==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "2.0.2",
@@ -3675,6 +5817,24 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fastify": {
       "version": "5.6.0",
@@ -6177,6 +8337,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/superagent": {
       "version": "8.1.2",


### PR DESCRIPTION
## Summary
- add donation and receipt sequence tables with Prisma models and migration
- introduce an S3-backed object storage plugin and donation services for PDF generation and CSV export
- expose authenticated /donations endpoints with coverage tests for numbering and receipt integrity

## Testing
- npm run lint *(fails: repository still uses .eslintrc and extends "prettier", which is unavailable under ESLint v9)*
- npm test *(fails: local PostgreSQL service is required for integration fixtures)*
- npm run build --workspace apps/api
- npm run build *(fails: apps/web workspace lacks an index.html entry for Vite)*

------
https://chatgpt.com/codex/tasks/task_e_68d38be638788323bcfe92651c3e6564