### PR TITLE
feat(api): add bullmq job worker and schedules

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,7 +10,8 @@
     "lint": "echo \"Lint is managed at the repository root\"",
     "format": "echo \"Format is managed at the repository root\"",
     "start": "node dist/main.js",
-    "prisma:migrate": "prisma migrate dev"
+    "prisma:migrate": "prisma migrate dev",
+    "jobs:worker": "ts-node-dev --respawn --transpile-only src/jobs/worker.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "3.895.0",
@@ -46,6 +47,7 @@
     "ts-node": "10.9.2",
     "ts-node-dev": "2.0.0",
     "typescript": "5.9.2",
-    "vitest": "2.1.4"
+    "vitest": "2.1.4",
+    "redis-memory-server": "0.10.0"
   }
 }

--- a/apps/api/src/__tests__/jobs.worker.test.ts
+++ b/apps/api/src/__tests__/jobs.worker.test.ts
@@ -1,0 +1,70 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import pino from 'pino';
+import { RedisMemoryServer } from 'redis-memory-server';
+import { JobRunner } from '../jobs/runner';
+import { createJobDefinitions } from '../jobs/definitions';
+
+describe('scheduled jobs worker', () => {
+  let redis: RedisMemoryServer;
+  let runner: JobRunner;
+  const executedJobs: string[] = [];
+  const listeners = new Map<string, () => void>();
+
+  beforeAll(async () => {
+    redis = await RedisMemoryServer.create();
+    const host = await redis.getHost();
+    const port = await redis.getPort();
+
+    const logger = pino({ level: 'silent' });
+
+    const definitions = createJobDefinitions({
+      logger,
+      timezone: 'UTC',
+      onJobExecuted: (jobKey) => {
+        executedJobs.push(jobKey);
+        listeners.get(jobKey)?.();
+      },
+    });
+
+    runner = new JobRunner({
+      connection: { host, port },
+      logger,
+      defaultTimezone: 'UTC',
+    });
+
+    await runner.registerScheduledJobs(definitions);
+  });
+
+  afterAll(async () => {
+    await runner.close();
+    await redis.stop();
+  });
+
+  it('registers repeatable jobs with persistence', async () => {
+    const membershipJobs = await runner.getRepeatableJobs('membership-fee-reminders');
+    const subsidyJobs = await runner.getRepeatableJobs('subsidy-deadline-notifications');
+    const backupJobs = await runner.getRepeatableJobs('nightly-backups');
+    const purgeJobs = await runner.getRepeatableJobs('gdpr-data-purge');
+
+    expect(membershipJobs).toHaveLength(1);
+    expect(subsidyJobs).toHaveLength(1);
+    expect(backupJobs).toHaveLength(1);
+    expect(purgeJobs).toHaveLength(1);
+
+    expect(membershipJobs[0]).toMatchObject({ name: 'membership-fee-reminders' });
+    expect(subsidyJobs[0]).toMatchObject({ name: 'subsidy-deadline-notifications' });
+    expect(backupJobs[0]).toMatchObject({ name: 'nightly-backups' });
+    expect(purgeJobs[0]).toMatchObject({ name: 'gdpr-data-purge' });
+  });
+
+  it('processes a job when triggered manually', async () => {
+    await new Promise<void>((resolve) => {
+      listeners.set('gdpr-data-purge', resolve);
+      void runner.runJobNow('gdpr-data-purge', { triggeredBy: 'test' }, 'test');
+    });
+
+    listeners.delete('gdpr-data-purge');
+    expect(executedJobs).toContain('gdpr-data-purge');
+  });
+});
+

--- a/apps/api/src/jobs/definitions.ts
+++ b/apps/api/src/jobs/definitions.ts
@@ -1,0 +1,69 @@
+import type { Job } from 'bullmq';
+import type { Logger } from 'pino';
+import type { ScheduledJobDefinition } from './runner';
+
+export interface JobDefinitionDependencies {
+  logger: Logger;
+  timezone?: string;
+  onJobExecuted?: (jobKey: string, job: Job) => void;
+}
+
+function createHandler(jobKey: string, message: string, deps: JobDefinitionDependencies) {
+  return async (job: Job): Promise<void> => {
+    deps.logger.info({ jobId: job.id, name: job.name, queue: job.queueName }, message);
+    await job.updateProgress(100);
+    deps.onJobExecuted?.(jobKey, job);
+  };
+}
+
+export function createJobDefinitions(deps: JobDefinitionDependencies): ScheduledJobDefinition[] {
+  const timezone = deps.timezone ?? 'Europe/Paris';
+
+  return [
+    {
+      key: 'membership-fee-reminders',
+      name: 'membership-fee-reminders',
+      queueName: 'membership-fee-reminders',
+      cron: '0 8 * * *',
+      timezone,
+      buildJobData: () => ({ jobType: 'membership-fee-reminders' }),
+      processor: createHandler(
+        'membership-fee-reminders',
+        'Processing membership fee reminder campaign',
+        deps
+      ),
+    },
+    {
+      key: 'subsidy-deadline-notifications',
+      name: 'subsidy-deadline-notifications',
+      queueName: 'subsidy-deadline-notifications',
+      cron: '0 7 * * 1',
+      timezone,
+      buildJobData: () => ({ jobType: 'subsidy-deadline-notifications' }),
+      processor: createHandler(
+        'subsidy-deadline-notifications',
+        'Processing subsidy deadline notification dispatch',
+        deps
+      ),
+    },
+    {
+      key: 'nightly-backups',
+      name: 'nightly-backups',
+      queueName: 'nightly-backups',
+      cron: '0 2 * * *',
+      timezone,
+      buildJobData: () => ({ jobType: 'nightly-backups' }),
+      processor: createHandler('nightly-backups', 'Processing nightly backup workflow', deps),
+    },
+    {
+      key: 'gdpr-data-purge',
+      name: 'gdpr-data-purge',
+      queueName: 'gdpr-data-purge',
+      cron: '0 3 * * *',
+      timezone,
+      buildJobData: () => ({ jobType: 'gdpr-data-purge' }),
+      processor: createHandler('gdpr-data-purge', 'Processing GDPR data purge routine', deps),
+    },
+  ];
+}
+

--- a/apps/api/src/jobs/runner.ts
+++ b/apps/api/src/jobs/runner.ts
@@ -1,0 +1,189 @@
+import { JobScheduler, Queue, Worker, type JobsOptions, type Processor, type WorkerOptions } from 'bullmq';
+import type { ConnectionOptions, RepeatOptions } from 'bullmq';
+import type { Logger } from 'pino';
+
+export interface ScheduledJobDefinition<Data = Record<string, unknown>, Result = void> {
+  /**
+   * Unique identifier for the scheduled job definition.
+   */
+  key: string;
+  /**
+   * Name used inside the BullMQ queue. Displayed in job listings.
+   */
+  name: string;
+  /**
+   * Queue name used to store repeatable jobs and manual triggers.
+   */
+  queueName: string;
+  /**
+   * Cron expression used to schedule the job.
+   */
+  cron: string;
+  /**
+   * Timezone used for the cron expression. Falls back to the runner default.
+   */
+  timezone?: string;
+  /**
+   * Optional payload used when registering the repeatable job. The same payload
+   * will be re-used for manual triggers when no custom data is provided.
+   */
+  buildJobData?: () => Promise<Data> | Data;
+  /**
+   * Additional BullMQ job options applied when registering the repeatable job.
+   */
+  jobOptions?: Omit<JobsOptions, 'repeat'>;
+  /**
+   * Optional worker options controlling concurrency, etc.
+   */
+  workerOptions?: WorkerOptions;
+  /**
+   * Handler executed when the job runs.
+   */
+  processor: Processor<Data, Result>;
+}
+
+interface RegisteredJob<Data = unknown, Result = unknown> {
+  definition: ScheduledJobDefinition<Data, Result>;
+  queue: Queue<Data, Result>;
+}
+
+export interface JobRunnerOptions {
+  connection: ConnectionOptions;
+  logger?: Logger;
+  defaultTimezone?: string;
+}
+
+export class JobRunner {
+  private readonly connection: ConnectionOptions;
+
+  private readonly logger?: Logger;
+
+  private readonly defaultTimezone: string;
+
+  private readonly definitions = new Map<string, RegisteredJob>();
+
+  private readonly queues: Queue[] = [];
+
+  private readonly schedulers: JobScheduler[] = [];
+
+  private readonly workers: Worker[] = [];
+
+  constructor(options: JobRunnerOptions) {
+    this.connection = options.connection;
+    this.logger = options.logger;
+    this.defaultTimezone = options.defaultTimezone ?? 'UTC';
+  }
+
+  async registerScheduledJobs(definitions: ScheduledJobDefinition[]): Promise<void> {
+    for (const definition of definitions) {
+      if (this.definitions.has(definition.key)) {
+        throw new Error(`Job definition with key "${definition.key}" already registered`);
+      }
+
+      const queue = new Queue(definition.queueName, { connection: this.connection });
+      await queue.waitUntilReady();
+      const scheduler = new JobScheduler(definition.queueName, { connection: this.connection });
+      await scheduler.waitUntilReady();
+
+      const worker = new Worker(definition.queueName, definition.processor, {
+        connection: this.connection,
+        ...definition.workerOptions,
+      });
+
+      worker.on('failed', (job, error) => {
+        this.logger?.error(
+          {
+            err: error,
+            jobId: job?.id,
+            jobName: job?.name,
+            queue: definition.queueName,
+          },
+          'Scheduled job failed'
+        );
+      });
+
+      this.queues.push(queue);
+      this.schedulers.push(scheduler);
+      this.workers.push(worker);
+      this.definitions.set(definition.key, { definition, queue });
+
+      await this.registerRepeatableJob(scheduler, definition);
+    }
+  }
+
+  async runJobNow<Data = Record<string, unknown>>(
+    key: string,
+    data?: Data,
+    jobNameSuffix = 'manual'
+  ): Promise<void> {
+    const registration = this.definitions.get(key);
+    if (!registration) {
+      throw new Error(`Unknown job definition with key "${key}"`);
+    }
+
+    const payload =
+      data ??
+      ((await registration.definition.buildJobData?.()) as Data | undefined) ??
+      ({} as Data);
+
+    await registration.queue.add(
+      `${registration.definition.name}:${jobNameSuffix}:${Date.now()}`,
+      payload,
+      {
+        removeOnComplete: true,
+        removeOnFail: 100,
+      }
+    );
+  }
+
+  async getRepeatableJobs(key: string) {
+    const registration = this.definitions.get(key);
+    if (!registration) {
+      throw new Error(`Unknown job definition with key "${key}"`);
+    }
+
+    return registration.queue.getRepeatableJobs();
+  }
+
+  async close(): Promise<void> {
+    await Promise.all(this.workers.map((worker) => worker.close()));
+    await Promise.all(this.schedulers.map((scheduler) => scheduler.close()));
+    await Promise.all(this.queues.map((queue) => queue.close()));
+  }
+
+  private async registerRepeatableJob<Data>(
+    scheduler: JobScheduler,
+    definition: ScheduledJobDefinition<Data>
+  ): Promise<void> {
+    const targetJobId = this.getRepeatJobId(definition);
+
+    await scheduler.removeJobScheduler(targetJobId).catch(() => undefined);
+
+    const jobData = (await definition.buildJobData?.()) ?? ({} as Data);
+
+    const repeat: RepeatOptions = {
+      pattern: definition.cron,
+      tz: definition.timezone ?? this.defaultTimezone,
+    };
+
+    const options: JobsOptions = {
+      removeOnComplete: true,
+      removeOnFail: 100,
+      ...definition.jobOptions,
+    };
+
+    await scheduler.upsertJobScheduler(
+      targetJobId,
+      repeat,
+      definition.name,
+      jobData,
+      options,
+      { override: true }
+    );
+  }
+
+  private getRepeatJobId(definition: ScheduledJobDefinition): string {
+    return `${definition.key}:repeat`;
+  }
+}
+

--- a/apps/api/src/jobs/worker.ts
+++ b/apps/api/src/jobs/worker.ts
@@ -1,0 +1,43 @@
+import 'dotenv/config';
+
+import pino from 'pino';
+import { JobRunner } from './runner';
+import { createJobDefinitions } from './definitions';
+
+async function main() {
+  const logger = pino({ level: process.env.LOG_LEVEL ?? 'info' });
+  const redisUrl = process.env.REDIS_URL && process.env.REDIS_URL.trim() !== ''
+    ? process.env.REDIS_URL
+    : 'redis://127.0.0.1:6379';
+
+  const runner = new JobRunner({
+    connection: { url: redisUrl },
+    logger,
+    defaultTimezone: process.env.JOBS_TIMEZONE ?? 'Europe/Paris',
+  });
+
+  const definitions = createJobDefinitions({
+    logger,
+    timezone: process.env.JOBS_TIMEZONE ?? 'Europe/Paris',
+  });
+
+  await runner.registerScheduledJobs(definitions);
+
+  logger.info({ redisUrl }, 'Background jobs worker started');
+
+  const shutdown = async (signal: NodeJS.Signals) => {
+    logger.info({ signal }, 'Shutting down jobs worker');
+    await runner.close();
+    process.exit(0);
+  };
+
+  process.once('SIGINT', () => void shutdown('SIGINT'));
+  process.once('SIGTERM', () => void shutdown('SIGTERM'));
+}
+
+void main().catch((error) => {
+  // eslint-disable-next-line no-console
+  console.error('Failed to start jobs worker', error);
+  process.exit(1);
+});
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "esbuild-register": "3.6.0",
         "pg": "8.13.1",
         "prisma": "6.16.2",
+        "redis-memory-server": "0.10.0",
         "supertest": "6.3.4",
         "ts-node": "10.9.2",
         "ts-node-dev": "2.0.0",
@@ -3968,6 +3969,17 @@
       "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
       "license": "MIT"
     },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.44.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.44.0.tgz",
@@ -4414,6 +4426,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -4658,6 +4680,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
@@ -4825,6 +4857,19 @@
         "upper-case": "^1.1.1"
       }
     },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/chai": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
@@ -4941,6 +4986,16 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/citty": {
@@ -5141,6 +5196,13 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/component-emitter": {
       "version": "1.3.1",
@@ -5605,6 +5667,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/entities": {
@@ -6156,6 +6228,27 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
     "node_modules/fast-check": {
       "version": "3.23.2",
       "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
@@ -6388,6 +6481,16 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -6413,6 +6516,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-cache-dir": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
+      }
+    },
     "node_modules/find-my-way": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.3.0.tgz",
@@ -6426,6 +6547,13 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/find-package-json": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/find-package-json/-/find-package-json-1.2.0.tgz",
+      "integrity": "sha512-+SOGcLGYDJHtyqHd87ysBhmaeQ95oWspDKnMXBrnQ9Eq4OkLNqejgoaD8xVWu6GPa0B6roa6KinCMEMcVeqONw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -6515,6 +6643,32 @@
         "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -6593,6 +6747,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-port": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
+      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
@@ -6605,6 +6772,22 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/giget": {
@@ -6841,6 +7024,20 @@
         "domhandler": "^5.0.3",
         "domutils": "^3.0.1",
         "entities": "^4.4.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/husky": {
@@ -7401,6 +7598,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lockfile": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.4.tgz",
+      "integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/lockfile/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -7411,6 +7625,13 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.defaultsdeep": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.1.tgz",
+      "integrity": "sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.includes": {
@@ -7524,6 +7745,32 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/make-error": {
@@ -7663,6 +7910,33 @@
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/mjml": {
@@ -8453,6 +8727,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -8626,6 +8910,13 @@
       "funding": {
         "url": "https://ko-fi.com/killymxi"
       }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/perfect-debounce": {
       "version": "1.0.0",
@@ -8810,6 +9101,75 @@
       "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
       "license": "MIT"
     },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/pkg-types": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
@@ -8989,6 +9349,17 @@
       "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
       "license": "ISC"
     },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -9114,6 +9485,101 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/redis-memory-server": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/redis-memory-server/-/redis-memory-server-0.10.0.tgz",
+      "integrity": "sha512-D0CFfUzAOQv/64iYzRqxUs4MEV2LlaW227qDvuuiq2FR4FXLrxyfENFf7dj6v4IwGTcNSLxhDlNKQthYVncg3Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "camelcase": "^6.3.0",
+        "cross-spawn": "^7.0.3",
+        "debug": "^4.3.4",
+        "extract-zip": "^2.0.1",
+        "find-cache-dir": "^3.3.2",
+        "find-package-json": "^1.2.0",
+        "get-port": "^5.1.1",
+        "https-proxy-agent": "^7.0.0",
+        "lockfile": "^1.0.4",
+        "lodash.defaultsdeep": "^4.6.1",
+        "mkdirp": "^3.0.1",
+        "rimraf": "^5.0.1",
+        "semver": "^7.5.3",
+        "tar": "^6.1.15",
+        "tmp": "^0.2.1",
+        "uuid": "^8.3.2"
+      },
+      "bin": {
+        "redis-memory-server": "bin/index.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/redis-memory-server/node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/redis-memory-server/node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/redis-memory-server/node_modules/rimraf": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/redis-memory-server/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/redis-parser": {
@@ -9842,6 +10308,34 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tar/node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -9900,6 +10394,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/to-regex-range": {
@@ -10716,6 +11220,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/yaml": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
@@ -10804,6 +11315,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     },
     "node_modules/yn": {


### PR DESCRIPTION
## Summary
- add a BullMQ-based job runner with repeatable scheduling helpers and graceful shutdown
- define recurring jobs for membership reminders, subsidy deadline alerts, nightly backups, and GDPR purges
- expose a dedicated worker entrypoint plus a Redis-backed integration test harness

## Testing
- npx vitest run src/__tests__/jobs.worker.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68d5773382dc8323a5f4c059089af529