### PR TITLE
Add PostgreSQL backup scripts and operations guide

### DIFF
--- a/docs/operations/database-backup.md
+++ b/docs/operations/database-backup.md
@@ -1,0 +1,143 @@
+# Sauvegardes PostgreSQL & Procédures de Restauration
+
+Ce document décrit la stratégie de sauvegarde et de restauration de la base de données PostgreSQL de l'application Association Management. Il couvre l'automatisation avec **pgBackRest** et **WAL-G**, la configuration du stockage S3 ainsi qu'un exercice trimestriel de restauration vers l'environnement *staging*.
+
+## 1. Stratégie de sauvegarde
+
+- **PITR** activé via archivage WAL (pgBackRest ou WAL-G).
+- **Sauvegarde complète quotidienne** (ou différentielle/incrémentale selon le moteur) avec conservation de 30 jours.
+- **Stockage S3** avec versioning et politiques de cycle de vie (90 jours en *Standard-IA*, 365 jours en *Deep Archive*).
+- **Test de restauration trimestriel** obligatoire sur *staging*.
+
+## 2. Scripts d'automatisation
+
+Les scripts sont situés dans `ops/backups/` et sont conçus pour être invoqués depuis des jobs cron ou un orchestrateur (GitHub Actions, Jenkins, etc.).
+
+### 2.1. Sauvegarde pgBackRest
+
+Script : `ops/backups/pgbackrest_backup.sh`
+
+```bash
+# Export des variables de connexion PostgreSQL et S3
+export PGHOST=db.internal
+export PGPORT=5432
+export PGUSER=postgres
+export PGPASSWORD=***
+export PG_BACKREST_STANZA=asso
+export PG_BACKREST_CONFIG=/etc/pgbackrest/pgbackrest.conf
+
+# Lancement de la sauvegarde (type automatique)
+/opt/asso/ops/backups/pgbackrest_backup.sh
+```
+
+Configuration pgBackRest minimale pour la rétention 30 jours :
+
+```ini
+[global]
+repo1-type=s3
+repo1-s3-bucket=asso-prod-backups
+repo1-path=/pgbackrest
+repo1-retention-full-type=time
+repo1-retention-full=30
+repo1-retention-archive-type=time
+repo1-retention-archive=30
+process-max=4
+
+[asso]
+pg1-path=/var/lib/postgresql/data
+```
+
+Cron quotidien (02:15 UTC) :
+
+```
+15 2 * * * /opt/asso/ops/backups/pgbackrest_backup.sh >> /var/log/pgbackrest_cron.log 2>&1
+```
+
+### 2.2. Sauvegarde WAL-G
+
+Script : `ops/backups/wal_g_backup.sh`
+
+```bash
+export PGHOST=db.internal
+export PGPORT=5432
+export PGUSER=postgres
+export PGPASSWORD=***
+export PGDATA=/var/lib/postgresql/data
+export WALG_S3_PREFIX=s3://asso-prod-backups/postgres
+
+/opt/asso/ops/backups/wal_g_backup.sh
+```
+
+Le script déclenche `wal-g backup-push` puis supprime les sauvegardes vieilles de plus de 30 jours (`wal-g delete before --confirm`). Planifier l'exécution quotidienne :
+
+```
+45 2 * * * /opt/asso/ops/backups/wal_g_backup.sh >> /var/log/wal_g_cron.log 2>&1
+```
+
+### 2.3. Configuration S3 (versioning + lifecycle)
+
+Script : `ops/backups/configure_s3.sh`
+
+```bash
+export BUCKET_NAME=asso-prod-backups
+export REGION=eu-west-3
+
+/opt/asso/ops/backups/configure_s3.sh
+```
+
+Le script :
+
+1. Crée le bucket si besoin.
+2. Active le **versioning**.
+3. Applique une politique de cycle de vie :
+   - Passage en **STANDARD_IA** après 90 jours.
+   - Passage en **DEEP_ARCHIVE** après 365 jours.
+   - Versions obsolètes déplacées en **DEEP_ARCHIVE** après 90 jours.
+
+## 3. Test de restauration trimestriel (staging)
+
+Script : `ops/backups/quarterly_restore_test.sh`
+
+```bash
+export RESTORE_TOOL=pgbackrest
+export STAGING_PGDATA=/var/lib/postgresql/staging
+export STAGING_CONNECTION_URI=postgresql://staging_user:***@staging-db.internal:5432/app
+export PG_BACKREST_STANZA=asso
+export PG_BACKREST_CONFIG=/etc/pgbackrest/pgbackrest.conf
+
+/opt/asso/ops/backups/quarterly_restore_test.sh
+```
+
+Par défaut le script :
+
+1. Purge et recrée le répertoire de données staging.
+2. Restaure la dernière sauvegarde (pgBackRest ou WAL-G selon `RESTORE_TOOL`).
+3. Exécute une requête de *smoke test* (`SELECT count(*) FROM pg_catalog.pg_tables;`).
+4. Journalise le succès dans `/var/log/asso_restore_audit.log`.
+
+Cron trimestriel (premier dimanche des trimestres à 02:00 UTC) :
+
+```
+0 2 1 JAN,APR,JUL,OCT * /opt/asso/ops/backups/quarterly_restore_test.sh >> /var/log/asso_restore.log 2>&1
+```
+
+Après chaque restauration :
+
+- L'équipe QA valide les fonctionnalités clés sur l'environnement *staging*.
+- Les journaux `/tmp/restore_smoke.log` et `/var/log/asso_restore_audit.log` sont archivés.
+- Les incidents sont consignée dans le registre qualité.
+
+## 4. Vérifications & supervision
+
+- Intégrer des alertes (Prometheus, Grafana) sur les métriques pgBackRest/WAL-G.
+- Surveiller la taille du bucket S3 et les coûts associés.
+- Activer des notifications en cas d'échec (mail, Slack, PagerDuty) depuis les jobs cron/CI.
+
+## 5. RACI
+
+| Tâche                                | Responsable | Support |
+|-------------------------------------|-------------|---------|
+| Exploitation des sauvegardes daily  | Ops         | DBA     |
+| Test de restauration trimestriel    | Ops         | QA      |
+| Gestion du bucket S3                | Ops         | SecOps  |
+| Vérification des journaux de backup | Ops         | —       |

--- a/ops/backups/configure_s3.sh
+++ b/ops/backups/configure_s3.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Configure an S3 bucket with versioning and lifecycle rules for database backups.
+#
+# Usage: BUCKET_NAME=asso-backups REGION=eu-west-3 ./configure_s3.sh
+# Requires AWS CLI v2 with credentials granting s3:PutBucketVersioning and
+# s3:PutLifecycleConfiguration permissions.
+
+BUCKET_NAME="${BUCKET_NAME:?Set BUCKET_NAME to the target bucket name}"
+REGION="${REGION:-eu-west-3}"
+
+if ! command -v aws >/dev/null 2>&1; then
+  echo "aws CLI not found in PATH" >&2
+  exit 1
+fi
+
+aws s3api create-bucket \
+  --bucket "${BUCKET_NAME}" \
+  --region "${REGION}" \
+  --create-bucket-configuration LocationConstraint="${REGION}" \
+  >/dev/null 2>&1 || true
+
+echo "Enabling versioning on s3://${BUCKET_NAME}"
+aws s3api put-bucket-versioning \
+  --bucket "${BUCKET_NAME}" \
+  --versioning-configuration Status=Enabled
+
+echo "Applying lifecycle policy (90 days current, 365 days glacier deep archive)"
+aws s3api put-bucket-lifecycle-configuration \
+  --bucket "${BUCKET_NAME}" \
+  --lifecycle-configuration ' {
+    "Rules": [
+      {
+        "ID": "DatabaseBackupsRetention",
+        "Status": "Enabled",
+        "Filter": { "Prefix": "" },
+        "Transitions": [
+          {
+            "Days": 90,
+            "StorageClass": "STANDARD_IA"
+          },
+          {
+            "Days": 365,
+            "StorageClass": "DEEP_ARCHIVE"
+          }
+        ],
+        "NoncurrentVersionTransitions": [
+          {
+            "NoncurrentDays": 90,
+            "StorageClass": "DEEP_ARCHIVE"
+          }
+        ],
+        "Expiration": { "ExpiredObjectDeleteMarker": true }
+      }
+    ]
+  }'
+
+echo "Lifecycle configuration applied."

--- a/ops/backups/pgbackrest_backup.sh
+++ b/ops/backups/pgbackrest_backup.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# pgBackRest backup launcher for the Association Management SaaS.
+#
+# This script orchestrates daily PostgreSQL backups with a 30-day retention policy
+# leveraging pgBackRest's time-based retention. It expects the pgBackRest
+# configuration to declare a stanza matching the value supplied via the
+# PG_BACKREST_STANZA environment variable (defaults to "asso").
+#
+# Required environment variables:
+#   - PGHOST / PGPORT / PGUSER / PGPASSWORD: connection parameters for the
+#     PostgreSQL instance to back up.
+#   - PG_BACKREST_STANZA: name of the stanza (default: "asso").
+#   - PG_BACKREST_CONFIG: path to the pgBackRest configuration file
+#     (default: /etc/pgbackrest/pgbackrest.conf).
+#
+# Optional environment variables:
+#   - BACKUP_TYPE: one of "full", "diff", "incr" (default: automatic). When
+#     omitted the script lets pgBackRest pick the optimal strategy based on the
+#     configured schedule.
+#   - LOG_LEVEL: overrides pgBackRest log level (default: info).
+#
+# The referenced pgBackRest configuration should include entries similar to:
+#
+# [global]
+# repo1-type=s3
+# repo1-s3-bucket=${PG_BACKREST_BUCKET}
+# repo1-s3-endpoint=${S3_ENDPOINT}
+# repo1-path=/pgbackrest
+# repo1-retention-full-type=time
+# repo1-retention-full=30
+# repo1-retention-archive-type=time
+# repo1-retention-archive=30
+# log-level-console=${LOG_LEVEL:-info}
+# process-max=4
+#
+# [${PG_BACKREST_STANZA:-asso}]
+# pg1-path=/var/lib/postgresql/data
+#
+# Ensure that WAL archiving is enabled in postgresql.conf:
+#   archive_mode = on
+#   archive_command = 'pgbackrest --stanza=${PG_BACKREST_STANZA} archive-push %p'
+
+PG_BACKREST_STANZA="${PG_BACKREST_STANZA:-asso}"
+PG_BACKREST_CONFIG="${PG_BACKREST_CONFIG:-/etc/pgbackrest/pgbackrest.conf}"
+BACKUP_TYPE="${BACKUP_TYPE:-}" # optional
+LOG_LEVEL="${LOG_LEVEL:-info}"
+
+if [[ ! -f "${PG_BACKREST_CONFIG}" ]]; then
+  echo "pgBackRest configuration not found at ${PG_BACKREST_CONFIG}" >&2
+  exit 1
+fi
+
+# Sanity check: ensure pgBackRest can reach the repository before launching the backup.
+pgbackrest --config="${PG_BACKREST_CONFIG}" --stanza="${PG_BACKREST_STANZA}" \
+  --log-level-console="${LOG_LEVEL}" info >/dev/null
+
+PG_BACKUP_ARGS=("--config=${PG_BACKREST_CONFIG}" "--stanza=${PG_BACKREST_STANZA}" "--log-level-console=${LOG_LEVEL}")
+if [[ -n "${BACKUP_TYPE}" ]]; then
+  PG_BACKUP_ARGS+=("--type=${BACKUP_TYPE}")
+fi
+
+pgbackrest "${PG_BACKUP_ARGS[@]}" backup

--- a/ops/backups/quarterly_restore_test.sh
+++ b/ops/backups/quarterly_restore_test.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Quarterly restoration drill for staging using pgBackRest or WAL-G backups.
+#
+# This job is intended to run from a staging bastion or CI runner with access to
+# the backup repository. It restores the latest backup into a disposable staging
+# database, runs a smoke test query, and hands the environment back to the
+# application team for validation.
+#
+# Required environment variables:
+#   - RESTORE_TOOL: "pgbackrest" or "wal-g" (defaults to pgbackrest)
+#   - STAGING_PGDATA: destination path for the restored data directory
+#   - STAGING_CONNECTION_URI: connection string to run smoke tests after restore
+#
+# pgBackRest-specific variables:
+#   - PG_BACKREST_STANZA (default: asso)
+#   - PG_BACKREST_CONFIG (default: /etc/pgbackrest/pgbackrest.conf)
+#
+# WAL-G-specific variables:
+#   - WALG_S3_PREFIX
+#   - PGUSER/PGPASSWORD/PGHOST/PGPORT for final vacuum/analyze steps
+#
+# Optional variables:
+#   - SMOKE_TEST_QUERY (default: 'SELECT count(*) FROM pg_catalog.pg_tables;')
+#   - PSQL (default: psql)
+#
+# Example crontab (run every quarter, first Sunday at 02:00 UTC):
+#   0 2 1 JAN,APR,JUL,OCT * /opt/asso/ops/backups/quarterly_restore_test.sh >> /var/log/asso_restore.log 2>&1
+
+RESTORE_TOOL="${RESTORE_TOOL:-pgbackrest}"
+STAGING_PGDATA="${STAGING_PGDATA:?Set STAGING_PGDATA to the target data directory}"
+SMOKE_TEST_QUERY="${SMOKE_TEST_QUERY:-SELECT count(*) FROM pg_catalog.pg_tables;}"
+PSQL_BIN="${PSQL:-psql}"
+
+prepare_staging_directory() {
+  rm -rf "${STAGING_PGDATA}"
+  mkdir -p "${STAGING_PGDATA}"
+  chmod 700 "${STAGING_PGDATA}"
+}
+
+run_pgbackrest_restore() {
+  local stanza config
+  stanza="${PG_BACKREST_STANZA:-asso}"
+  config="${PG_BACKREST_CONFIG:-/etc/pgbackrest/pgbackrest.conf}"
+
+  pgbackrest --config="${config}" --stanza="${stanza}" \
+    --delta --recovery-option=target-action=promote \
+    --target="latest" --log-level-console=info \
+    --pg1-path="${STAGING_PGDATA}" restore
+}
+
+run_walg_restore() {
+  if [[ -z "${WALG_S3_PREFIX:-}" ]]; then
+    echo "WALG_S3_PREFIX must be defined to use WAL-G restore" >&2
+    exit 1
+  fi
+
+  export PGDATA="${STAGING_PGDATA}"
+  wal-g backup-fetch "${STAGING_PGDATA}" LATEST
+  wal-g wal-fetch "${STAGING_PGDATA}" LATEST || true
+}
+
+run_smoke_test() {
+  local uri
+  uri="${STAGING_CONNECTION_URI:?Set STAGING_CONNECTION_URI for smoke tests}"
+  echo "Running smoke test query on restored database"
+  echo "${SMOKE_TEST_QUERY}" | ${PSQL_BIN} "${uri}" --set ON_ERROR_STOP=1 >/tmp/restore_smoke.log
+}
+
+prepare_staging_directory
+
+case "${RESTORE_TOOL}" in
+  pgbackrest)
+    run_pgbackrest_restore
+    ;;
+  wal-g)
+    run_walg_restore
+    ;;
+  *)
+    echo "Unsupported RESTORE_TOOL: ${RESTORE_TOOL}" >&2
+    exit 1
+    ;;
+esac
+
+run_smoke_test
+
+echo "Restore drill completed successfully at $(date -Is)" >> /var/log/asso_restore_audit.log

--- a/ops/backups/wal_g_backup.sh
+++ b/ops/backups/wal_g_backup.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# WAL-G backup helper keeping 30 days of backups for PITR.
+#
+# Required environment variables:
+#   - WALG_S3_PREFIX: destination (e.g. s3://asso-backups/postgres)
+#   - PGHOST / PGPORT / PGUSER / PGPASSWORD: PostgreSQL connection info
+#   - PGDATA: path to the PostgreSQL data directory (for tar backups)
+#   - AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY (or IAM role)
+#
+# Optional environment variables:
+#   - WALG_DELTA_MAX_STEPS (defaults to 7)
+#   - BACKUP_TYPE: "full" or "delta" (default: auto)
+#
+# The script triggers a base backup with WAL-G and prunes anything older than 30 days.
+
+export WALG_DELTA_MAX_STEPS="${WALG_DELTA_MAX_STEPS:-7}"
+export WALG_DOWNLOAD_CONCURRENCY="${WALG_DOWNLOAD_CONCURRENCY:-4}"
+export WALG_UPLOAD_CONCURRENCY="${WALG_UPLOAD_CONCURRENCY:-4}"
+BACKUP_TYPE="${BACKUP_TYPE:-}" # optional hint for wal-g backup-push
+
+if [[ -z "${WALG_S3_PREFIX:-}" ]]; then
+  echo "WALG_S3_PREFIX must be set (e.g. s3://asso-backups/postgres)" >&2
+  exit 1
+fi
+
+if ! command -v wal-g >/dev/null 2>&1; then
+  echo "wal-g binary not found in PATH" >&2
+  exit 1
+fi
+
+# Run the backup. WAL-G automatically infers the type when BACKUP_TYPE is empty.
+if [[ -n "${BACKUP_TYPE}" ]]; then
+  wal-g backup-push --${BACKUP_TYPE} "${PGDATA}"
+else
+  wal-g backup-push "${PGDATA}"
+fi
+
+# Retention: delete backups strictly older than 30 days and their WAL segments.
+wal-g delete before "$(date -u -d '30 days ago' +%Y-%m-%dT%H:%M:%SZ)" --confirm


### PR DESCRIPTION
## Summary
- add scripted pgBackRest and WAL-G backups with 30-day retention handling
- provide S3 bucket configuration automation including versioning and lifecycle policies
- document backup, S3, and quarterly restore drill procedures for ops teams

## Testing
- not run (documentation and shell scripting only)


------
https://chatgpt.com/codex/tasks/task_e_68d5847a240c83239f0943fd9de6d667