### PR TITLE
feat(web): add auth flow with protected layout and tests

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,6 +10,8 @@
     "vue-router": "4.4.5"
   },
   "devDependencies": {
+    "@testing-library/user-event": "14.6.1",
+    "@testing-library/vue": "8.1.0",
     "@types/node": "22.10.1",
     "@vitejs/plugin-vue": "5.2.1",
     "autoprefixer": "10.4.20",

--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -1,11 +1,23 @@
 <template>
-  <MainLayout>
+  <component :is="layoutComponent">
     <RouterView />
-  </MainLayout>
+  </component>
 </template>
 
 <script setup lang="ts">
-import { RouterView } from 'vue-router';
+import { computed } from 'vue';
+import { RouterView, useRoute } from 'vue-router';
 
+import AuthLayout from './layouts/AuthLayout.vue';
 import MainLayout from './layouts/MainLayout.vue';
+
+const route = useRoute();
+
+const layoutComponent = computed(() => {
+  const layout = route.meta.layout;
+  if (layout === 'auth') {
+    return AuthLayout;
+  }
+  return MainLayout;
+});
 </script>

--- a/apps/web/src/layouts/AuthLayout.vue
+++ b/apps/web/src/layouts/AuthLayout.vue
@@ -1,0 +1,29 @@
+<template>
+  <div class="flex min-h-screen flex-col bg-muted px-4 py-12">
+    <header class="mx-auto w-full max-w-md pb-8 text-center">
+      <RouterLink to="/" class="inline-flex items-center gap-3 text-foreground">
+        <span class="flex h-12 w-12 items-center justify-center rounded-2xl bg-primary text-lg font-semibold text-primary-foreground">
+          As
+        </span>
+        <span class="flex flex-col text-left leading-tight">
+          <span class="text-base font-semibold">Asso</span>
+          <span class="text-xs text-muted-foreground">Gestion &amp; Comptabilité</span>
+        </span>
+      </RouterLink>
+    </header>
+
+    <main class="mx-auto w-full max-w-md">
+      <section class="rounded-3xl border border-outline/40 bg-surface p-8 shadow-soft">
+        <slot />
+      </section>
+    </main>
+
+    <footer class="mx-auto mt-auto w-full max-w-md py-6 text-center text-xs text-muted-foreground">
+      &copy; {{ new Date().getFullYear() }} Asso. Tous droits réservés.
+    </footer>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { RouterLink } from 'vue-router';
+</script>

--- a/apps/web/src/layouts/MainLayout.vue
+++ b/apps/web/src/layouts/MainLayout.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="min-h-screen bg-background">
     <header class="border-b border-outline bg-surface/80 backdrop-blur">
-      <div class="app-container flex items-center justify-between py-4">
+      <div class="app-container flex items-center justify-between gap-6 py-4">
         <RouterLink to="/" class="flex items-center gap-3 text-foreground">
           <span class="flex h-11 w-11 items-center justify-center rounded-2xl bg-primary text-lg font-semibold text-primary-foreground">
             As
@@ -25,7 +25,9 @@
         </nav>
 
         <div class="flex items-center gap-3">
-          <BaseButton variant="outline" class="hidden md:inline-flex">Nouvelle écriture</BaseButton>
+          <BaseButton v-if="canCreateEntry" variant="outline" class="hidden md:inline-flex">
+            Nouvelle écriture
+          </BaseButton>
           <button
             type="button"
             class="inline-flex h-10 w-10 items-center justify-center rounded-lg border border-outline/80 text-muted-foreground transition-colors hover:text-primary md:hidden"
@@ -35,6 +37,25 @@
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-5 w-5">
               <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
             </svg>
+          </button>
+          <div v-if="user" class="hidden items-center gap-2 rounded-full border border-outline/70 bg-surface px-3 py-1 text-left text-xs md:flex">
+            <span class="flex h-8 w-8 items-center justify-center rounded-full bg-primary/10 font-semibold text-primary">
+              {{ userInitials }}
+            </span>
+            <div class="flex flex-col leading-tight">
+              <span class="text-sm font-medium text-foreground">{{ user.displayName ?? user.email }}</span>
+              <span class="text-[11px] uppercase tracking-wide text-muted-foreground">
+                {{ user.roles.join(', ') }}
+              </span>
+            </div>
+          </div>
+          <button
+            v-if="isAuthenticated"
+            type="button"
+            class="hidden text-xs font-medium text-muted-foreground transition-colors hover:text-primary md:inline-flex"
+            @click="logout"
+          >
+            Se déconnecter
           </button>
         </div>
       </div>
@@ -76,11 +97,22 @@
           {{ item.label }}
         </RouterLink>
       </nav>
-      <BaseButton variant="primary" class="mt-auto">Nouvelle écriture</BaseButton>
+      <BaseButton v-if="canCreateEntry" variant="primary" class="mt-auto">Nouvelle écriture</BaseButton>
+      <button
+        v-if="isAuthenticated"
+        type="button"
+        class="text-left text-sm font-medium text-muted-foreground transition-colors hover:text-primary"
+        @click="logout"
+      >
+        Se déconnecter
+      </button>
     </aside>
 
     <main class="app-container grid gap-6 py-10 md:grid-cols-[220px,1fr]">
-      <aside class="hidden h-fit rounded-2xl border border-outline/60 bg-surface p-6 shadow-soft md:block">
+      <aside
+        v-if="navigation.length"
+        class="hidden h-fit rounded-2xl border border-outline/60 bg-surface p-6 shadow-soft md:block"
+      >
         <nav class="flex flex-col gap-2 text-sm font-medium">
           <p class="text-xs uppercase tracking-wide text-muted-foreground">Navigation</p>
           <RouterLink
@@ -115,23 +147,46 @@
 
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, watch } from 'vue';
-import { useRoute } from 'vue-router';
+import { useRoute, useRouter } from 'vue-router';
 
 import BaseButton from '@/components/ui/BaseButton.vue';
-import { useAppStore } from '@/store';
+import { useAppStore, useAuthStore, type UserRole } from '@/store';
 
 const route = useRoute();
+const router = useRouter();
 const appStore = useAppStore();
+const authStore = useAuthStore();
 
-const navigation = computed(() => [
-  { label: 'Tableau de bord', to: '/', matchName: 'dashboard.home' },
-  { label: 'Comptabilité', to: '/comptabilite', matchName: 'accounting.overview' },
-  { label: 'Membres', to: '/membres', matchName: 'members.list' },
-  { label: 'Subventions', to: '/subventions', matchName: 'grants.list' },
+const rawNavigation = computed(() => [
+  { label: 'Tableau de bord', to: '/', matchName: 'dashboard.home', requiredRoles: ['ADMIN', 'TREASURER', 'SECRETARY', 'VIEWER'] as UserRole[] },
+  { label: 'Comptabilité', to: '/comptabilite', matchName: 'accounting.overview', requiredRoles: ['ADMIN', 'TREASURER'] as UserRole[] },
+  { label: 'Membres', to: '/membres', matchName: 'members.list', requiredRoles: ['ADMIN', 'TREASURER', 'SECRETARY'] as UserRole[] },
+  { label: 'Subventions', to: '/subventions', matchName: 'grants.list', requiredRoles: ['ADMIN', 'TREASURER', 'SECRETARY'] as UserRole[] },
 ]);
+
+const navigation = computed(() =>
+  rawNavigation.value.filter((item) => authStore.hasAnyRole(item.requiredRoles)),
+);
 
 const isSidebarOpen = computed(() => appStore.sidebarOpen);
 const currentRouteName = computed(() => route.name);
+const isAuthenticated = computed(() => authStore.isAuthenticated);
+const user = computed(() => authStore.user);
+const canCreateEntry = computed(() => authStore.hasAnyRole(['ADMIN', 'TREASURER']));
+const userInitials = computed(() => {
+  if (!user.value) {
+    return '';
+  }
+  const name = user.value.displayName ?? user.value.email;
+  const initials = name
+    .split(/\s+/)
+    .map((segment) => segment.trim())
+    .filter(Boolean)
+    .map((segment) => segment[0]?.toUpperCase() ?? '')
+    .join('');
+
+  return initials.slice(0, 2);
+});
 
 function toggleSidebar() {
   appStore.toggleSidebar();
@@ -139,6 +194,11 @@ function toggleSidebar() {
 
 function closeSidebar() {
   appStore.closeSidebar();
+}
+
+async function logout() {
+  authStore.logout();
+  await router.push({ name: 'auth.login' });
 }
 
 watch(

--- a/apps/web/src/modules/accounting/routes.ts
+++ b/apps/web/src/modules/accounting/routes.ts
@@ -7,6 +7,8 @@ export const accountingRoutes: RouteRecordRaw[] = [
     component: () => import('./views/AccountingOverview.vue'),
     meta: {
       layout: 'main',
+      requiresAuth: true,
+      requiredRoles: ['ADMIN', 'TREASURER'],
       title: 'Comptabilité',
     },
   },

--- a/apps/web/src/modules/auth/routes.ts
+++ b/apps/web/src/modules/auth/routes.ts
@@ -1,0 +1,35 @@
+import type { RouteRecordRaw } from 'vue-router';
+
+export const authRoutes: RouteRecordRaw[] = [
+  {
+    path: '/connexion',
+    name: 'auth.login',
+    component: () => import('./views/LoginView.vue'),
+    meta: {
+      layout: 'auth',
+      public: true,
+      title: 'Connexion',
+    },
+  },
+  {
+    path: '/mot-de-passe-oublie',
+    name: 'auth.forgot',
+    component: () => import('./views/ForgotPasswordView.vue'),
+    meta: {
+      layout: 'auth',
+      public: true,
+      title: 'Mot de passe oublié',
+    },
+  },
+  {
+    path: '/reinitialisation-mot-de-passe',
+    name: 'auth.reset',
+    component: () => import('./views/ResetPasswordView.vue'),
+    props: (route) => ({ token: route.query.token as string | undefined }),
+    meta: {
+      layout: 'auth',
+      public: true,
+      title: 'Réinitialiser le mot de passe',
+    },
+  },
+];

--- a/apps/web/src/modules/auth/views/ForgotPasswordView.vue
+++ b/apps/web/src/modules/auth/views/ForgotPasswordView.vue
@@ -1,0 +1,97 @@
+<template>
+  <section class="space-y-8">
+    <header class="space-y-2 text-center">
+      <h1 class="text-3xl font-display font-semibold text-foreground">Mot de passe oublié</h1>
+      <p class="text-sm text-muted-foreground">
+        Saisissez votre adresse e-mail pour recevoir un lien de réinitialisation.
+      </p>
+    </header>
+
+    <form class="space-y-5" @submit.prevent="handleSubmit" novalidate>
+      <div class="space-y-1">
+        <label for="forgot-email" class="text-sm font-medium text-foreground">Adresse e-mail</label>
+        <input
+          id="forgot-email"
+          v-model="email"
+          type="email"
+          autocomplete="email"
+          required
+          class="w-full rounded-xl border border-outline/60 bg-background px-4 py-3 text-sm text-foreground shadow-soft focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+        />
+      </div>
+
+      <p v-if="errorMessage" class="text-sm text-destructive" role="alert">{{ errorMessage }}</p>
+      <p v-if="successMessage" class="text-sm text-primary" role="status">{{ successMessage }}</p>
+
+      <button
+        type="submit"
+        class="inline-flex w-full items-center justify-center rounded-xl bg-primary px-4 py-3 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+        :disabled="!canSubmit"
+      >
+        <svg
+          v-if="isSubmitting"
+          class="mr-2 h-4 w-4 animate-spin"
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4l3-3-3-3v4a12 12 0 100 24v-4l-3 3 3 3v-4a8 8 0 01-8-8z" />
+        </svg>
+        Envoyer le lien
+      </button>
+    </form>
+
+    <p class="text-center text-sm text-muted-foreground">
+      <RouterLink to="/connexion" class="font-medium text-primary transition-colors hover:text-primary/80">
+        Retour à la connexion
+      </RouterLink>
+    </p>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { RouterLink } from 'vue-router';
+
+const email = ref('');
+const isSubmitting = ref(false);
+const successMessage = ref('');
+const errorMessage = ref('');
+
+const canSubmit = computed(() => Boolean(email.value.trim()) && !isSubmitting.value);
+
+async function handleSubmit() {
+  if (!canSubmit.value) {
+    return;
+  }
+
+  errorMessage.value = '';
+  successMessage.value = '';
+  isSubmitting.value = true;
+
+  try {
+    const response = await fetch('/api/v1/auth/forgot-password', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ email: email.value.trim() }),
+    });
+
+    if (!response.ok) {
+      const data = await response.json().catch(() => null);
+      const detail = data?.detail ?? data?.message;
+      throw new Error(detail ?? 'Impossible d\'envoyer le lien.');
+    }
+
+    successMessage.value =
+      'Si cette adresse est enregistrée, un lien de réinitialisation vient de vous être envoyé.';
+  } catch (error) {
+    errorMessage.value = error instanceof Error ? error.message : 'Impossible d\'envoyer le lien.';
+  } finally {
+    isSubmitting.value = false;
+  }
+}
+</script>

--- a/apps/web/src/modules/auth/views/LoginView.vue
+++ b/apps/web/src/modules/auth/views/LoginView.vue
@@ -1,0 +1,103 @@
+<template>
+  <section class="space-y-8">
+    <header class="space-y-2 text-center">
+      <h1 class="text-3xl font-display font-semibold text-foreground">Connexion</h1>
+      <p class="text-sm text-muted-foreground">Accédez à votre espace de gestion associatif.</p>
+    </header>
+
+    <form class="space-y-5" @submit.prevent="handleSubmit" novalidate>
+      <div class="space-y-1">
+        <label for="email" class="text-sm font-medium text-foreground">Adresse e-mail</label>
+        <input
+          id="email"
+          v-model="form.email"
+          type="email"
+          autocomplete="email"
+          required
+          class="w-full rounded-xl border border-outline/60 bg-background px-4 py-3 text-sm text-foreground shadow-soft focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+        />
+      </div>
+
+      <div class="space-y-1">
+        <label for="password" class="text-sm font-medium text-foreground">Mot de passe</label>
+        <input
+          id="password"
+          v-model="form.password"
+          type="password"
+          autocomplete="current-password"
+          required
+          class="w-full rounded-xl border border-outline/60 bg-background px-4 py-3 text-sm text-foreground shadow-soft focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+        />
+      </div>
+
+      <p v-if="errorMessage" class="text-sm text-destructive" role="alert">{{ errorMessage }}</p>
+
+      <button
+        type="submit"
+        class="inline-flex w-full items-center justify-center rounded-xl bg-primary px-4 py-3 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+        :disabled="!canSubmit"
+      >
+        <svg
+          v-if="isSubmitting"
+          class="mr-2 h-4 w-4 animate-spin"
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4l3-3-3-3v4a12 12 0 100 24v-4l-3 3 3 3v-4a8 8 0 01-8-8z" />
+        </svg>
+        Se connecter
+      </button>
+    </form>
+
+    <p class="text-center text-sm text-muted-foreground">
+      <RouterLink to="/mot-de-passe-oublie" class="font-medium text-primary transition-colors hover:text-primary/80">
+        Mot de passe oublié ?
+      </RouterLink>
+    </p>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, reactive, ref } from 'vue';
+import { RouterLink, useRoute, useRouter } from 'vue-router';
+
+import { useAuthStore } from '@/store';
+
+const router = useRouter();
+const route = useRoute();
+const authStore = useAuthStore();
+
+const form = reactive({
+  email: '',
+  password: '',
+});
+
+const isSubmitting = ref(false);
+const errorMessage = ref('');
+
+const canSubmit = computed(() => {
+  return Boolean(form.email.trim()) && Boolean(form.password.trim()) && !isSubmitting.value;
+});
+
+async function handleSubmit() {
+  if (!canSubmit.value) {
+    return;
+  }
+
+  errorMessage.value = '';
+  isSubmitting.value = true;
+
+  try {
+    await authStore.login({ email: form.email.trim(), password: form.password });
+    const redirect = typeof route.query.redirect === 'string' && route.query.redirect ? route.query.redirect : '/';
+    await router.push(redirect);
+  } catch (error) {
+    errorMessage.value = error instanceof Error ? error.message : 'Connexion impossible.';
+  } finally {
+    isSubmitting.value = false;
+  }
+}
+</script>

--- a/apps/web/src/modules/auth/views/ResetPasswordView.vue
+++ b/apps/web/src/modules/auth/views/ResetPasswordView.vue
@@ -1,0 +1,141 @@
+<template>
+  <section class="space-y-8">
+    <header class="space-y-2 text-center">
+      <h1 class="text-3xl font-display font-semibold text-foreground">Réinitialiser le mot de passe</h1>
+      <p class="text-sm text-muted-foreground">
+        Choisissez un nouveau mot de passe pour sécuriser votre compte.
+      </p>
+    </header>
+
+    <div v-if="!token" class="rounded-xl border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive">
+      Le lien de réinitialisation est invalide ou expiré. Veuillez refaire une demande.
+    </div>
+
+    <form v-else class="space-y-5" @submit.prevent="handleSubmit" novalidate>
+      <div class="space-y-1">
+        <label for="password" class="text-sm font-medium text-foreground">Nouveau mot de passe</label>
+        <input
+          id="password"
+          v-model="password"
+          type="password"
+          autocomplete="new-password"
+          required
+          class="w-full rounded-xl border border-outline/60 bg-background px-4 py-3 text-sm text-foreground shadow-soft focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+        />
+      </div>
+
+      <div class="space-y-1">
+        <label for="confirm-password" class="text-sm font-medium text-foreground">Confirmer le mot de passe</label>
+        <input
+          id="confirm-password"
+          v-model="confirmation"
+          type="password"
+          autocomplete="new-password"
+          required
+          class="w-full rounded-xl border border-outline/60 bg-background px-4 py-3 text-sm text-foreground shadow-soft focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+        />
+      </div>
+
+      <p v-if="errorMessage" class="text-sm text-destructive" role="alert">{{ errorMessage }}</p>
+      <p v-if="successMessage" class="text-sm text-primary" role="status">{{ successMessage }}</p>
+
+      <button
+        type="submit"
+        class="inline-flex w-full items-center justify-center rounded-xl bg-primary px-4 py-3 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+        :disabled="!canSubmit"
+      >
+        <svg
+          v-if="isSubmitting"
+          class="mr-2 h-4 w-4 animate-spin"
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4l3-3-3-3v4a12 12 0 100 24v-4l-3 3 3 3v-4a8 8 0 01-8-8z" />
+        </svg>
+        Mettre à jour le mot de passe
+      </button>
+    </form>
+
+    <p class="text-center text-sm text-muted-foreground">
+      <RouterLink to="/connexion" class="font-medium text-primary transition-colors hover:text-primary/80">
+        Retour à la connexion
+      </RouterLink>
+    </p>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue';
+import { RouterLink } from 'vue-router';
+
+type Props = {
+  token?: string;
+};
+
+const props = defineProps<Props>();
+
+const password = ref('');
+const confirmation = ref('');
+const isSubmitting = ref(false);
+const successMessage = ref('');
+const errorMessage = ref('');
+
+const canSubmit = computed(() => {
+  return (
+    Boolean(props.token) &&
+    Boolean(password.value.trim()) &&
+    password.value.trim().length >= 8 &&
+    password.value === confirmation.value &&
+    !isSubmitting.value
+  );
+});
+
+watch(
+  () => [password.value, confirmation.value],
+  () => {
+    if (password.value && confirmation.value && password.value !== confirmation.value) {
+      errorMessage.value = 'Les mots de passe doivent être identiques.';
+    } else {
+      errorMessage.value = '';
+    }
+  },
+);
+
+async function handleSubmit() {
+  if (!canSubmit.value || !props.token) {
+    return;
+  }
+
+  errorMessage.value = '';
+  successMessage.value = '';
+  isSubmitting.value = true;
+
+  try {
+    const response = await fetch('/api/v1/auth/reset-password', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ token: props.token, password: password.value }),
+    });
+
+    if (!response.ok) {
+      const data = await response.json().catch(() => null);
+      const detail = data?.detail ?? data?.message;
+      throw new Error(detail ?? 'Impossible de mettre à jour le mot de passe.');
+    }
+
+    successMessage.value = 'Votre mot de passe a été mis à jour avec succès.';
+    password.value = '';
+    confirmation.value = '';
+  } catch (error) {
+    errorMessage.value =
+      error instanceof Error ? error.message : 'Impossible de mettre à jour le mot de passe.';
+  } finally {
+    isSubmitting.value = false;
+  }
+}
+</script>

--- a/apps/web/src/modules/auth/views/__tests__/ForgotPasswordView.spec.ts
+++ b/apps/web/src/modules/auth/views/__tests__/ForgotPasswordView.spec.ts
@@ -1,0 +1,77 @@
+import { render, screen, waitFor } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
+import { defineComponent, h } from 'vue';
+
+import ForgotPasswordView from '../ForgotPasswordView.vue';
+
+function createMockResponse(body: unknown, ok = true) {
+  return {
+    ok,
+    async json() {
+      return body;
+    },
+  } as Response;
+}
+
+const RouterLinkStub = defineComponent({
+  name: 'RouterLinkStub',
+  props: {
+    to: {
+      type: [String, Object],
+      required: false,
+    },
+  },
+  setup(props, { slots }) {
+    return () =>
+      h(
+        'a',
+        {
+          href:
+            typeof props.to === 'string'
+              ? props.to
+              : (props.to as { path?: string } | undefined)?.path ?? '#',
+        },
+        slots.default ? slots.default() : [],
+      );
+  },
+});
+
+describe('ForgotPasswordView', () => {
+  afterEach(() => {
+    window.localStorage.clear();
+    vi.unstubAllGlobals();
+  });
+
+  it('sends a reset link to the provided e-mail address', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(createMockResponse({}, true));
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(ForgotPasswordView, {
+      global: {
+        stubs: {
+          RouterLink: RouterLinkStub,
+        },
+      },
+    });
+
+    const user = userEvent.setup();
+
+    await user.type(screen.getByLabelText(/adresse e-mail/i), 'membre@example.com');
+    await user.click(screen.getByRole('button', { name: /envoyer le lien/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/auth/forgot-password',
+        expect.objectContaining({
+          method: 'POST',
+        }),
+      );
+    });
+
+    expect(
+      screen.getByText(
+        /Si cette adresse est enregistrée, un lien de réinitialisation vient de vous être envoyé\./i,
+      ),
+    ).toBeTruthy();
+  });
+});

--- a/apps/web/src/modules/auth/views/__tests__/LoginView.spec.ts
+++ b/apps/web/src/modules/auth/views/__tests__/LoginView.spec.ts
@@ -1,0 +1,78 @@
+import { render, screen, waitFor } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
+import { createPinia, setActivePinia } from 'pinia';
+import { createMemoryHistory } from 'vue-router';
+
+import LoginView from '../LoginView.vue';
+import { createAppRouter } from '@/router';
+import { useAuthStore } from '@/store';
+
+function createMockResponse(body: unknown, ok = true) {
+  return {
+    ok,
+    async json() {
+      return body;
+    },
+  } as Response;
+}
+
+describe('LoginView', () => {
+  beforeAll(() => {
+    (window as unknown as { scrollTo?: () => void }).scrollTo = vi.fn();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+    vi.unstubAllGlobals();
+  });
+
+  it('authenticates the user and redirects to the dashboard', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      createMockResponse({
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+        expiresIn: 3600,
+        user: { id: '1', email: 'admin@example.com', roles: ['ADMIN'] },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const pinia = createPinia();
+    setActivePinia(pinia);
+
+    const router = createAppRouter(createMemoryHistory());
+    await router.push('/connexion');
+    await router.isReady();
+
+    render(LoginView, {
+      global: {
+        plugins: [pinia, router],
+      },
+    });
+
+    const user = userEvent.setup();
+
+    await user.type(screen.getByLabelText(/adresse e-mail/i), 'admin@example.com');
+    await user.type(screen.getByLabelText(/mot de passe/i), 'secret123');
+    await user.click(screen.getByRole('button', { name: /se connecter/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/auth/login',
+        expect.objectContaining({
+          method: 'POST',
+        }),
+      );
+    });
+
+    const authStore = useAuthStore();
+
+    await waitFor(() => {
+      expect(authStore.isAuthenticated).toBe(true);
+    });
+
+    await waitFor(() => {
+      expect(router.currentRoute.value.name).toBe('dashboard.home');
+    });
+  });
+});

--- a/apps/web/src/modules/auth/views/__tests__/ResetPasswordView.spec.ts
+++ b/apps/web/src/modules/auth/views/__tests__/ResetPasswordView.spec.ts
@@ -1,0 +1,94 @@
+import { render, screen, waitFor } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
+import { defineComponent, h } from 'vue';
+
+import ResetPasswordView from '../ResetPasswordView.vue';
+
+function createMockResponse(body: unknown, ok = true) {
+  return {
+    ok,
+    async json() {
+      return body;
+    },
+  } as Response;
+}
+
+const RouterLinkStub = defineComponent({
+  name: 'RouterLinkStub',
+  props: {
+    to: {
+      type: [String, Object],
+      required: false,
+    },
+  },
+  setup(props, { slots }) {
+    return () =>
+      h(
+        'a',
+        {
+          href:
+            typeof props.to === 'string'
+              ? props.to
+              : (props.to as { path?: string } | undefined)?.path ?? '#',
+        },
+        slots.default ? slots.default() : [],
+      );
+  },
+});
+
+describe('ResetPasswordView', () => {
+  afterEach(() => {
+    window.localStorage.clear();
+    vi.unstubAllGlobals();
+  });
+
+  it('updates the password when the token is valid', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(createMockResponse({}, true));
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(ResetPasswordView, {
+      props: {
+        token: 'reset-token',
+      },
+      global: {
+        stubs: {
+          RouterLink: RouterLinkStub,
+        },
+      },
+    });
+
+    const user = userEvent.setup();
+
+    await user.type(screen.getByLabelText(/nouveau mot de passe/i), 'supersecret');
+    await user.type(screen.getByLabelText(/confirmer le mot de passe/i), 'supersecret');
+    await user.click(screen.getByRole('button', { name: /mettre à jour le mot de passe/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/auth/reset-password',
+        expect.objectContaining({
+          method: 'POST',
+        }),
+      );
+    });
+
+    expect(
+      screen.getByText(/Votre mot de passe a été mis à jour avec succès\./i),
+    ).toBeTruthy();
+  });
+
+  it('disables the form when the token is missing', () => {
+    render(ResetPasswordView, {
+      global: {
+        stubs: {
+          RouterLink: RouterLinkStub,
+        },
+      },
+    });
+
+    expect(
+      screen.getByText(/Le lien de réinitialisation est invalide ou expiré/i),
+    ).toBeTruthy();
+    expect(screen.getByRole('link', { name: /retour à la connexion/i })).toBeTruthy();
+  });
+});

--- a/apps/web/src/modules/dashboard/routes.ts
+++ b/apps/web/src/modules/dashboard/routes.ts
@@ -7,6 +7,8 @@ export const dashboardRoutes: RouteRecordRaw[] = [
     component: () => import('./views/DashboardHome.vue'),
     meta: {
       layout: 'main',
+      requiresAuth: true,
+      requiredRoles: ['ADMIN', 'TREASURER', 'SECRETARY', 'VIEWER'],
       title: 'Tableau de bord',
     },
   },

--- a/apps/web/src/modules/grants/routes.ts
+++ b/apps/web/src/modules/grants/routes.ts
@@ -7,6 +7,8 @@ export const grantsRoutes: RouteRecordRaw[] = [
     component: () => import('./views/GrantsList.vue'),
     meta: {
       layout: 'main',
+      requiresAuth: true,
+      requiredRoles: ['ADMIN', 'TREASURER', 'SECRETARY'],
       title: 'Subventions',
     },
   },

--- a/apps/web/src/modules/members/routes.ts
+++ b/apps/web/src/modules/members/routes.ts
@@ -7,6 +7,8 @@ export const membersRoutes: RouteRecordRaw[] = [
     component: () => import('./views/MembersList.vue'),
     meta: {
       layout: 'main',
+      requiresAuth: true,
+      requiredRoles: ['ADMIN', 'TREASURER', 'SECRETARY'],
       title: 'Membres',
     },
   },

--- a/apps/web/src/router/index.ts
+++ b/apps/web/src/router/index.ts
@@ -1,18 +1,50 @@
-import { createRouter, createWebHistory } from 'vue-router';
+import { createRouter, createWebHistory, type RouterHistory } from 'vue-router';
 
 import { accountingRoutes } from '@/modules/accounting/routes';
+import { authRoutes } from '@/modules/auth/routes';
 import { dashboardRoutes } from '@/modules/dashboard/routes';
 import { grantsRoutes } from '@/modules/grants/routes';
 import { membersRoutes } from '@/modules/members/routes';
+import { useAuthStore, type UserRole } from '@/store';
 
-const routes = [...dashboardRoutes, ...accountingRoutes, ...membersRoutes, ...grantsRoutes];
+const routes = [...authRoutes, ...dashboardRoutes, ...accountingRoutes, ...membersRoutes, ...grantsRoutes];
 
-const router = createRouter({
-  history: createWebHistory(import.meta.env.BASE_URL),
-  routes,
-  scrollBehavior() {
-    return { top: 0 };
-  },
-});
+export function createAppRouter(history: RouterHistory = createWebHistory(import.meta.env.BASE_URL)) {
+  const router = createRouter({
+    history,
+    routes,
+    scrollBehavior() {
+      return { top: 0 };
+    },
+  });
+
+  router.beforeEach(async (to) => {
+    const authStore = useAuthStore();
+
+    if (!authStore.isInitialized) {
+      await authStore.initializeFromStorage();
+    }
+
+    if (to.meta.public) {
+      return true;
+    }
+
+    if (to.meta.requiresAuth && !authStore.isAuthenticated) {
+      const redirectQuery = to.fullPath && to.fullPath !== '/connexion' ? { redirect: to.fullPath } : undefined;
+      return redirectQuery ? { name: 'auth.login', query: redirectQuery } : { name: 'auth.login' };
+    }
+
+    const requiredRoles = (to.meta.requiredRoles as UserRole[] | undefined) ?? [];
+    if (to.meta.requiresAuth && requiredRoles.length && !authStore.hasAnyRole(requiredRoles)) {
+      return { name: 'dashboard.home' };
+    }
+
+    return true;
+  });
+
+  return router;
+}
+
+const router = createAppRouter();
 
 export default router;

--- a/apps/web/src/store/auth.ts
+++ b/apps/web/src/store/auth.ts
@@ -1,0 +1,248 @@
+import { defineStore } from 'pinia';
+
+type RefreshTimeout = ReturnType<typeof setTimeout> | null;
+
+export type UserRole = 'ADMIN' | 'TREASURER' | 'SECRETARY' | 'VIEWER';
+
+export interface AuthenticatedUser {
+  id: string;
+  email: string;
+  displayName?: string;
+  roles: UserRole[];
+}
+
+interface LoginResponse {
+  accessToken: string;
+  refreshToken: string;
+  expiresIn: number;
+  user: AuthenticatedUser;
+}
+
+interface RefreshResponse {
+  accessToken: string;
+  refreshToken: string;
+  expiresIn: number;
+  user?: AuthenticatedUser;
+}
+
+interface PersistedSession {
+  accessToken: string | null;
+  refreshToken: string | null;
+  expiresAt: number | null;
+  user: AuthenticatedUser | null;
+}
+
+interface AuthState extends PersistedSession {
+  status: 'idle' | 'authenticating' | 'authenticated';
+  error: string | null;
+  refreshTimeoutId: RefreshTimeout;
+  isInitialized: boolean;
+}
+
+const STORAGE_KEY = 'asso.auth.session';
+const API_BASE_URL = '/api/v1/auth';
+
+async function readErrorMessage(response: Response) {
+  try {
+    const data = await response.json();
+    if (typeof data?.detail === 'string') {
+      return data.detail;
+    }
+    if (typeof data?.message === 'string') {
+      return data.message;
+    }
+  } catch (error) {
+    console.warn('Unable to parse error response', error);
+  }
+  return 'Une erreur est survenue. Veuillez réessayer.';
+}
+
+export const useAuthStore = defineStore('auth', {
+  state: (): AuthState => ({
+    accessToken: null,
+    refreshToken: null,
+    expiresAt: null,
+    user: null,
+    status: 'idle',
+    error: null,
+    refreshTimeoutId: null,
+    isInitialized: false,
+  }),
+  getters: {
+    isAuthenticated: (state) => Boolean(state.accessToken),
+    roles: (state) => state.user?.roles ?? [],
+    hasRole() {
+      return (role: UserRole) => this.roles.includes(role);
+    },
+    hasAnyRole() {
+      return (expectedRoles: UserRole[]) => {
+        if (!expectedRoles.length) {
+          return true;
+        }
+        return expectedRoles.some((role) => this.roles.includes(role));
+      };
+    },
+    authorizationHeader: (state) =>
+      state.accessToken ? { Authorization: `Bearer ${state.accessToken}` } : undefined,
+  },
+  actions: {
+    async initializeFromStorage() {
+      if (this.isInitialized) {
+        return;
+      }
+
+      if (typeof window === 'undefined') {
+        this.isInitialized = true;
+        return;
+      }
+
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+      if (raw) {
+        try {
+          const parsed = JSON.parse(raw) as PersistedSession;
+          this.accessToken = parsed.accessToken;
+          this.refreshToken = parsed.refreshToken;
+          this.expiresAt = parsed.expiresAt;
+          this.user = parsed.user ?? null;
+
+          if (this.accessToken && this.refreshToken && this.expiresAt) {
+            const secondsUntilExpiration = Math.floor((this.expiresAt - Date.now()) / 1000);
+            if (secondsUntilExpiration <= 0) {
+              await this.refreshTokens().catch(() => this.logout());
+            } else {
+              this.scheduleRefresh(secondsUntilExpiration);
+              this.status = 'authenticated';
+            }
+          }
+        } catch (error) {
+          console.warn('Unable to restore authentication session', error);
+          window.localStorage.removeItem(STORAGE_KEY);
+        }
+      }
+
+      this.isInitialized = true;
+    },
+    async login(payload: { email: string; password: string }) {
+      if (this.status === 'authenticating') {
+        return;
+      }
+
+      this.status = 'authenticating';
+      this.error = null;
+
+      try {
+        const response = await fetch(`${API_BASE_URL}/login`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(payload),
+        });
+
+        if (!response.ok) {
+          throw new Error(await readErrorMessage(response));
+        }
+
+        const data = (await response.json()) as LoginResponse;
+        this.applySession(data.accessToken, data.refreshToken, data.expiresIn, data.user);
+        this.status = 'authenticated';
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Connexion impossible.';
+        this.error = message;
+        this.status = 'idle';
+        throw error;
+      }
+    },
+    async refreshTokens() {
+      if (!this.refreshToken) {
+        throw new Error('Token de rafraîchissement absent.');
+      }
+
+      try {
+        const response = await fetch(`${API_BASE_URL}/refresh`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ refreshToken: this.refreshToken }),
+        });
+
+        if (!response.ok) {
+          throw new Error(await readErrorMessage(response));
+        }
+
+        const data = (await response.json()) as RefreshResponse;
+        this.applySession(
+          data.accessToken,
+          data.refreshToken,
+          data.expiresIn,
+          data.user ?? this.user ?? null,
+        );
+      } catch (error) {
+        this.logout();
+        throw error;
+      }
+    },
+    logout() {
+      this.clearRefreshTimer();
+      this.accessToken = null;
+      this.refreshToken = null;
+      this.expiresAt = null;
+      this.user = null;
+      this.status = 'idle';
+      this.error = null;
+      this.persistSession();
+    },
+    clearRefreshTimer() {
+      if (this.refreshTimeoutId) {
+        clearTimeout(this.refreshTimeoutId);
+        this.refreshTimeoutId = null;
+      }
+    },
+    applySession(
+      accessToken: string,
+      refreshToken: string,
+      expiresIn: number,
+      user: AuthenticatedUser | null,
+    ) {
+      this.accessToken = accessToken;
+      this.refreshToken = refreshToken;
+      this.expiresAt = Date.now() + expiresIn * 1000;
+      this.user = user;
+      this.error = null;
+      this.status = 'authenticated';
+      this.persistSession();
+      this.scheduleRefresh(expiresIn);
+    },
+    scheduleRefresh(expiresInSeconds: number) {
+      this.clearRefreshTimer();
+      if (typeof window === 'undefined') {
+        return;
+      }
+      const refreshDelay = Math.max(expiresInSeconds - 30, 5) * 1000;
+      this.refreshTimeoutId = window.setTimeout(() => {
+        this.refreshTokens().catch(() => {
+          this.logout();
+        });
+      }, refreshDelay);
+    },
+    persistSession() {
+      if (typeof window === 'undefined') {
+        return;
+      }
+
+      const payload: PersistedSession = {
+        accessToken: this.accessToken,
+        refreshToken: this.refreshToken,
+        expiresAt: this.expiresAt,
+        user: this.user,
+      };
+
+      if (!payload.accessToken && !payload.refreshToken) {
+        window.localStorage.removeItem(STORAGE_KEY);
+      } else {
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+      }
+    },
+  },
+});

--- a/apps/web/src/store/index.ts
+++ b/apps/web/src/store/index.ts
@@ -1,1 +1,2 @@
 export * from './app';
+export * from './auth';

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,6 +83,8 @@
         "vue-router": "4.4.5"
       },
       "devDependencies": {
+        "@testing-library/user-event": "14.6.1",
+        "@testing-library/vue": "8.1.0",
         "@types/node": "22.10.1",
         "@vitejs/plugin-vue": "5.2.1",
         "autoprefixer": "10.4.20",
@@ -1533,6 +1535,21 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -7458,6 +7475,95 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@testing-library/vue": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/vue/-/vue-8.1.0.tgz",
+      "integrity": "sha512-ls4RiHO1ta4mxqqajWRh8158uFObVrrtAPoxk7cIp4HrnQUj/ScKzqz53HxYpG3X6Zb7H2v+0eTGLSoy8HQ2nA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2",
+        "@testing-library/dom": "^9.3.3",
+        "@vue/test-utils": "^2.4.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@vue/compiler-sfc": ">= 3",
+        "vue": ">= 3"
+      },
+      "peerDependenciesMeta": {
+        "@vue/compiler-sfc": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/vue/node_modules/@testing-library/dom": {
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.4.tgz",
+      "integrity": "sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.1.3",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@testing-library/vue/node_modules/aria-query": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
+      "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "deep-equal": "^2.0.5"
+      }
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
@@ -7483,6 +7589,13 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
       "license": "MIT"
     },
@@ -8241,6 +8354,17 @@
       "integrity": "sha512-L2RPSAwUFbgZH20etwrXyVyCBu9OxRSi8T/38QsvnkJyvq2LufW2lDCOzm7t/U9C1mkhJGWYfCuFBCmIuNivrg==",
       "license": "MIT"
     },
+    "node_modules/@vue/test-utils": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.4.6.tgz",
+      "integrity": "sha512-FMxEjOpYNYiFe0GkaHsnJPXFHxQ6m4t8vI/ElPGpMWxZKpmRvQ33OIrvRXemy6yha03RxhOlQuy+gZMC3CQSow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-beautify": "^1.14.9",
+        "vue-component-type-helpers": "^2.0.0"
+      }
+    },
     "node_modules/abbrev": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
@@ -8476,6 +8600,34 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
@@ -8545,6 +8697,22 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/avvio": {
@@ -8803,6 +8971,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -9506,6 +9693,39 @@
         "node": ">=6"
       }
     },
+    "node_modules/deep-equal": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
+      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.0",
+        "call-bind": "^1.0.5",
+        "es-get-iterator": "^1.1.3",
+        "get-intrinsic": "^1.2.2",
+        "is-arguments": "^1.1.1",
+        "is-array-buffer": "^3.0.2",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.5.1",
+        "side-channel": "^1.0.4",
+        "which-boxed-primitive": "^1.0.2",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -9530,6 +9750,42 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/defu": {
@@ -9637,6 +9893,13 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -9939,6 +10202,27 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-get-iterator": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "is-arguments": "^1.1.1",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
+        "is-string": "^1.0.7",
+        "isarray": "^2.0.5",
+        "stop-iteration-iterator": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/es-object-atoms": {
@@ -10762,6 +11046,22 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -10876,6 +11176,16 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -11123,6 +11433,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -11131,6 +11454,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-symbols": {
@@ -11388,6 +11724,21 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/ioredis": {
       "version": "5.8.0",
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.8.0.tgz",
@@ -11421,6 +11772,57 @@
         "node": ">= 10"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -11433,6 +11835,36 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-core-module": {
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
@@ -11440,6 +11872,23 @@
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -11485,6 +11934,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -11492,6 +11954,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-path-inside": {
@@ -11511,6 +11990,54 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -11522,6 +12049,78 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -11603,6 +12202,13 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -12147,6 +12753,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -13109,6 +13725,54 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/obuf": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
@@ -13728,6 +14392,16 @@
         "pathe": "^2.0.3"
       }
     },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
@@ -13954,6 +14628,44 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/prisma": {
       "version": "6.16.2",
       "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.16.2.tgz",
@@ -14151,6 +14863,13 @@
         "destr": "^2.0.3"
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -14312,6 +15031,27 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/relateurl": {
@@ -14544,6 +15284,24 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/safe-regex2": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.0.0.tgz",
@@ -14637,6 +15395,40 @@
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
       "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
       "license": "MIT"
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -14865,6 +15657,20 @@
       "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/string-argv": {
       "version": "0.3.2",
@@ -15905,6 +16711,13 @@
         }
       }
     },
+    "node_modules/vue-component-type-helpers": {
+      "version": "2.2.12",
+      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-2.2.12.tgz",
+      "integrity": "sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/vue-eslint-parser": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-10.2.0.tgz",
@@ -16146,6 +16959,67 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/why-is-node-running": {


### PR DESCRIPTION
## Summary
- add a dedicated authentication layout and switch layouts dynamically based on route metadata
- create a Pinia auth store with JWT persistence, automatic refresh, and router guards tied to role-based access
- implement login/forgot/reset password views with API calls, update module routes for RBAC, and cover the flows with Vitest tests

## Testing
- `npm run test -w apps/web`
- `npm run build -w apps/web`
- `npm run lint` *(fails: ESLint configuration missing in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68d58ee165f88323940caedd2b0624f6