### PR TITLE
feat: enhance member management workflows

### DIFF
--- a/apps/web/src/layouts/MainLayout.vue
+++ b/apps/web/src/layouts/MainLayout.vue
@@ -162,6 +162,12 @@ const rawNavigation = computed(() => [
   { label: 'Comptabilité', to: '/comptabilite', matchName: 'accounting.overview', requiredRoles: ['ADMIN', 'TREASURER'] as UserRole[] },
   { label: 'Membres', to: '/membres', matchName: 'members.list', requiredRoles: ['ADMIN', 'TREASURER', 'SECRETARY'] as UserRole[] },
   { label: 'Subventions', to: '/subventions', matchName: 'grants.list', requiredRoles: ['ADMIN', 'TREASURER', 'SECRETARY'] as UserRole[] },
+  {
+    label: 'Portail adhérent',
+    to: '/portail/membre',
+    matchName: 'members.selfService',
+    requiredRoles: ['ADMIN', 'TREASURER', 'SECRETARY', 'VIEWER'] as UserRole[],
+  },
 ]);
 
 const navigation = computed(() =>

--- a/apps/web/src/modules/members/data.ts
+++ b/apps/web/src/modules/members/data.ts
@@ -1,0 +1,272 @@
+export interface MemberContribution {
+  id: string;
+  label: string;
+  amount: number;
+  dueDate: string;
+  status: 'paid' | 'pending' | 'overdue';
+  paymentDate?: string;
+  lastReminderAt?: string;
+  reminderCount: number;
+  receiptUrl?: string;
+}
+
+export interface MemberInvoice {
+  id: string;
+  label: string;
+  issueDate: string;
+  dueDate: string;
+  amount: number;
+  status: 'paid' | 'pending' | 'overdue';
+  downloadUrl: string;
+}
+
+export interface MemberPayment {
+  id: string;
+  amount: number;
+  date: string;
+  method: 'Carte' | 'Virement' | 'Espèces' | 'Chèque';
+  reference: string;
+  note?: string;
+  receiptUrl?: string;
+}
+
+export interface MemberProfile {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone: string;
+  address: string;
+  membershipType: string;
+  status: 'A_JOUR' | 'EN_RETARD' | 'EN_ATTENTE';
+  joinDate: string;
+  nextRenewalDate: string;
+  lastPaymentDate?: string;
+  outstandingBalance: number;
+  totalContributions: number;
+  tags: string[];
+  contributions: MemberContribution[];
+  payments: MemberPayment[];
+  invoices: MemberInvoice[];
+}
+
+export const membersDirectory: MemberProfile[] = [
+  {
+    id: 'mem-001',
+    firstName: 'Lina',
+    lastName: 'Durand',
+    email: 'lina.durand@example.org',
+    phone: '+33 6 12 34 56 78',
+    address: '12 rue des Glycines, 75011 Paris',
+    membershipType: 'Adhésion annuelle',
+    status: 'A_JOUR',
+    joinDate: '2021-09-12',
+    nextRenewalDate: '2025-09-30',
+    lastPaymentDate: '2024-09-18',
+    outstandingBalance: 0,
+    totalContributions: 320,
+    tags: ['Bénévole', 'Bureau'],
+    contributions: [
+      {
+        id: 'cot-2024-001',
+        label: 'Cotisation 2024',
+        amount: 160,
+        dueDate: '2024-09-30',
+        status: 'paid',
+        paymentDate: '2024-09-18',
+        reminderCount: 0,
+        receiptUrl: '/documents/recus/cotisation-2024.pdf',
+      },
+      {
+        id: 'cot-2025-001',
+        label: 'Cotisation 2025',
+        amount: 160,
+        dueDate: '2025-09-30',
+        status: 'pending',
+        reminderCount: 0,
+      },
+    ],
+    payments: [
+      {
+        id: 'pay-2024-001',
+        amount: 160,
+        date: '2024-09-18',
+        method: 'Virement',
+        reference: 'VIR-SEPA-98432',
+        note: 'Renouvellement adhésion 2024',
+        receiptUrl: '/documents/recus/cotisation-2024.pdf',
+      },
+      {
+        id: 'pay-2023-001',
+        amount: 160,
+        date: '2023-09-19',
+        method: 'Carte',
+        reference: 'CB-4857',
+        note: 'Cotisation annuelle',
+        receiptUrl: '/documents/recus/cotisation-2023.pdf',
+      },
+    ],
+    invoices: [
+      {
+        id: 'inv-2024-001',
+        label: 'Facture cotisation 2024',
+        issueDate: '2024-08-31',
+        dueDate: '2024-09-30',
+        amount: 160,
+        status: 'paid',
+        downloadUrl: '/documents/factures/facture-cotisation-2024.pdf',
+      },
+      {
+        id: 'inv-2025-001',
+        label: 'Facture cotisation 2025',
+        issueDate: '2025-08-31',
+        dueDate: '2025-09-30',
+        amount: 160,
+        status: 'pending',
+        downloadUrl: '/documents/factures/facture-cotisation-2025.pdf',
+      },
+    ],
+  },
+  {
+    id: 'mem-002',
+    firstName: 'Sofiane',
+    lastName: 'Benali',
+    email: 'sofiane.benali@example.org',
+    phone: '+33 7 81 45 09 22',
+    address: '8 avenue des Tilleuls, 69003 Lyon',
+    membershipType: 'Tarif solidaire',
+    status: 'EN_RETARD',
+    joinDate: '2022-01-04',
+    nextRenewalDate: '2025-02-28',
+    lastPaymentDate: '2023-02-18',
+    outstandingBalance: 90,
+    totalContributions: 270,
+    tags: ['Public cible', 'Projet Inclusion'],
+    contributions: [
+      {
+        id: 'cot-2023-014',
+        label: 'Cotisation 2023',
+        amount: 90,
+        dueDate: '2023-02-28',
+        status: 'paid',
+        paymentDate: '2023-02-18',
+        reminderCount: 1,
+        receiptUrl: '/documents/recus/cotisation-2023-014.pdf',
+      },
+      {
+        id: 'cot-2024-014',
+        label: 'Cotisation 2024',
+        amount: 90,
+        dueDate: '2024-02-28',
+        status: 'overdue',
+        reminderCount: 3,
+        lastReminderAt: '2024-05-05',
+      },
+      {
+        id: 'cot-2025-014',
+        label: 'Cotisation 2025',
+        amount: 90,
+        dueDate: '2025-02-28',
+        status: 'pending',
+        reminderCount: 0,
+      },
+    ],
+    payments: [
+      {
+        id: 'pay-2023-014',
+        amount: 90,
+        date: '2023-02-18',
+        method: 'Chèque',
+        reference: 'CHEQUE-1025',
+        note: 'Cotisation solidaire',
+        receiptUrl: '/documents/recus/cotisation-2023-014.pdf',
+      },
+    ],
+    invoices: [
+      {
+        id: 'inv-2024-014',
+        label: 'Facture cotisation 2024',
+        issueDate: '2024-01-31',
+        dueDate: '2024-02-28',
+        amount: 90,
+        status: 'overdue',
+        downloadUrl: '/documents/factures/facture-cotisation-2024-014.pdf',
+      },
+      {
+        id: 'inv-2025-014',
+        label: 'Facture cotisation 2025',
+        issueDate: '2025-01-31',
+        dueDate: '2025-02-28',
+        amount: 90,
+        status: 'pending',
+        downloadUrl: '/documents/factures/facture-cotisation-2025-014.pdf',
+      },
+    ],
+  },
+  {
+    id: 'mem-003',
+    firstName: 'Zoé',
+    lastName: 'Martinelli',
+    email: 'zoe.martinelli@example.org',
+    phone: '+33 6 77 02 41 88',
+    address: '27 boulevard de la République, 44000 Nantes',
+    membershipType: 'Adhésion famille',
+    status: 'EN_ATTENTE',
+    joinDate: '2024-04-22',
+    nextRenewalDate: '2025-04-30',
+    outstandingBalance: 0,
+    totalContributions: 180,
+    tags: ['Nouvelle adhérente'],
+    contributions: [
+      {
+        id: 'cot-2024-033',
+        label: 'Cotisation 2024',
+        amount: 180,
+        dueDate: '2024-04-30',
+        status: 'paid',
+        paymentDate: '2024-04-25',
+        reminderCount: 0,
+        receiptUrl: '/documents/recus/cotisation-2024-033.pdf',
+      },
+      {
+        id: 'cot-2025-033',
+        label: 'Cotisation 2025',
+        amount: 180,
+        dueDate: '2025-04-30',
+        status: 'pending',
+        reminderCount: 0,
+      },
+    ],
+    payments: [
+      {
+        id: 'pay-2024-033',
+        amount: 180,
+        date: '2024-04-25',
+        method: 'Carte',
+        reference: 'CB-9901',
+        note: 'Première adhésion',
+        receiptUrl: '/documents/recus/cotisation-2024-033.pdf',
+      },
+    ],
+    invoices: [
+      {
+        id: 'inv-2024-033',
+        label: 'Facture cotisation 2024',
+        issueDate: '2024-04-01',
+        dueDate: '2024-04-30',
+        amount: 180,
+        status: 'paid',
+        downloadUrl: '/documents/factures/facture-cotisation-2024-033.pdf',
+      },
+      {
+        id: 'inv-2025-033',
+        label: 'Facture cotisation 2025',
+        issueDate: '2025-04-01',
+        dueDate: '2025-04-30',
+        amount: 180,
+        status: 'pending',
+        downloadUrl: '/documents/factures/facture-cotisation-2025-033.pdf',
+      },
+    ],
+  },
+];

--- a/apps/web/src/modules/members/routes.ts
+++ b/apps/web/src/modules/members/routes.ts
@@ -12,4 +12,38 @@ export const membersRoutes: RouteRecordRaw[] = [
       title: 'Membres',
     },
   },
+  {
+    path: '/membres/statuts-cotisations',
+    name: 'members.contributions',
+    component: () => import('./views/ContributionsStatus.vue'),
+    meta: {
+      layout: 'main',
+      requiresAuth: true,
+      requiredRoles: ['ADMIN', 'TREASURER', 'SECRETARY'],
+      title: 'Statut des cotisations',
+    },
+  },
+  {
+    path: '/membres/:memberId',
+    name: 'members.detail',
+    component: () => import('./views/MemberDetail.vue'),
+    props: true,
+    meta: {
+      layout: 'main',
+      requiresAuth: true,
+      requiredRoles: ['ADMIN', 'TREASURER', 'SECRETARY'],
+      title: 'Fiche membre',
+    },
+  },
+  {
+    path: '/portail/membre',
+    name: 'members.selfService',
+    component: () => import('./views/MemberSelfService.vue'),
+    meta: {
+      layout: 'main',
+      requiresAuth: true,
+      requiredRoles: ['ADMIN', 'TREASURER', 'SECRETARY', 'VIEWER'],
+      title: 'Portail adhérent',
+    },
+  },
 ];

--- a/apps/web/src/modules/members/views/ContributionsStatus.vue
+++ b/apps/web/src/modules/members/views/ContributionsStatus.vue
@@ -1,0 +1,263 @@
+<template>
+  <section class="space-y-8">
+    <header class="space-y-3">
+      <BaseBadge variant="accent">Cotisations</BaseBadge>
+      <h1 class="text-3xl font-display font-semibold tracking-tight text-foreground sm:text-4xl">
+        Statut des cotisations et relances
+      </h1>
+      <p class="max-w-2xl text-sm text-muted-foreground">
+        Suivez en temps réel les adhésions payées, en attente ou en retard, et déclenchez les relances ciblées.
+      </p>
+    </header>
+
+    <div class="grid gap-5 md:grid-cols-3">
+      <BaseCard>
+        <template #title>Cotisations payées</template>
+        <template #description>Montant encaissé sur l'exercice en cours.</template>
+        <p class="text-3xl font-semibold text-foreground">{{ paidTotal }} €</p>
+      </BaseCard>
+      <BaseCard>
+        <template #title>En attente</template>
+        <template #description>Adhésions à valider avant échéance.</template>
+        <p class="text-3xl font-semibold text-accent">{{ pendingTotal }} €</p>
+      </BaseCard>
+      <BaseCard>
+        <template #title>Retards critiques</template>
+        <template #description>Montant à recouvrer avec relance prioritaire.</template>
+        <p class="text-3xl font-semibold text-destructive">{{ overdueTotal }} €</p>
+      </BaseCard>
+    </div>
+
+    <div
+      v-if="overdueItems.length"
+      data-testid="reminder-banner"
+      class="flex flex-col gap-3 rounded-2xl border border-destructive/50 bg-destructive/10 p-5 text-sm text-destructive"
+    >
+      <div class="flex items-center gap-2 font-semibold">
+        <span class="text-lg">⚠️</span>
+        <span>{{ overdueItems.length }} relance(s) urgentes à traiter cette semaine.</span>
+      </div>
+      <p class="text-destructive/80">
+        Dernière relance envoyée le {{ formatDate(overdueItems[0].lastReminderAt ?? overdueItems[0].dueDate) }} pour
+        {{ overdueItems[0].memberName }}. Pensez à générer un reçu après régularisation.
+      </p>
+      <div class="flex flex-wrap gap-2">
+        <BaseButton variant="secondary" @click="navigateToMember(overdueItems[0].memberId)">
+          Ouvrir la fiche prioritaire
+        </BaseButton>
+        <BaseButton variant="outline" @click="generateReminderBatch">Programmer les relances</BaseButton>
+      </div>
+      <p v-if="reminderQueued" class="text-xs text-destructive/80">
+        Les relances ont été planifiées. Vous recevrez un récapitulatif par email.
+      </p>
+    </div>
+
+    <div class="overflow-hidden rounded-2xl border border-outline/50">
+      <table class="min-w-full divide-y divide-outline/60 text-sm">
+        <thead class="bg-muted/40 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          <tr>
+            <th class="px-5 py-4">Membre</th>
+            <th class="px-5 py-4">Cotisation</th>
+            <th class="px-5 py-4">Échéance</th>
+            <th class="px-5 py-4">Montant</th>
+            <th class="px-5 py-4">Statut</th>
+            <th class="px-5 py-4">Dernière relance</th>
+            <th class="px-5 py-4 text-right">Actions</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-outline/40 bg-surface">
+          <tr
+            v-for="item in contributionRows"
+            :key="item.id"
+            class="transition-colors hover:bg-muted/40"
+            :class="focusedMemberId === item.memberId ? 'bg-primary/5 ring-2 ring-primary/40' : ''"
+          >
+            <td class="px-5 py-4">
+              <button
+                type="button"
+                class="text-left font-medium text-foreground hover:text-primary"
+                @click="navigateToMember(item.memberId)"
+              >
+                {{ item.memberName }}
+              </button>
+              <p class="text-xs text-muted-foreground">{{ item.membershipType }}</p>
+            </td>
+            <td class="px-5 py-4 text-muted-foreground">{{ item.label }}</td>
+            <td class="px-5 py-4 text-muted-foreground">{{ formatDate(item.dueDate) }}</td>
+            <td class="px-5 py-4 font-semibold text-foreground">{{ item.amount.toFixed(2) }} €</td>
+            <td class="px-5 py-4">
+              <BaseBadge :variant="badgeVariant(item.status)" :class="badgeClass(item.status)">
+                {{ badgeLabel(item.status) }}
+              </BaseBadge>
+            </td>
+            <td class="px-5 py-4 text-muted-foreground">
+              <span v-if="item.status === 'paid'">Aucune relance nécessaire</span>
+              <span v-else-if="item.lastReminderAt">
+                {{ formatDate(item.lastReminderAt) }} ({{ item.reminderCount }} envois)
+              </span>
+              <span v-else>Aucune</span>
+            </td>
+            <td class="px-5 py-4">
+              <div class="flex justify-end gap-2">
+                <BaseButton
+                  variant="secondary"
+                  class="px-3 py-1.5 text-xs"
+                  @click="registerPayment(item.memberId, item.amount)"
+                >
+                  Enregistrer un paiement
+                </BaseButton>
+                <BaseButton variant="outline" class="px-3 py-1.5 text-xs" @click="queueReminder(item.memberId)">
+                  Relancer
+                </BaseButton>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+
+import BaseBadge from '@/components/ui/BaseBadge.vue';
+import BaseButton from '@/components/ui/BaseButton.vue';
+import BaseCard from '@/components/ui/BaseCard.vue';
+
+import { membersDirectory, type MemberContribution, type MemberProfile } from '../data';
+
+type ContributionRow = {
+  id: string;
+  memberId: string;
+  memberName: string;
+  membershipType: string;
+  label: string;
+  amount: number;
+  dueDate: string;
+  status: MemberContribution['status'];
+  reminderCount: number;
+  lastReminderAt?: string;
+};
+
+type BadgeVariant = 'primary' | 'secondary' | 'accent' | 'outline' | 'success';
+
+const route = useRoute();
+const router = useRouter();
+
+const focusedMemberId = computed(() => (route.query.focus as string | undefined) ?? null);
+
+const contributionRows = computed<ContributionRow[]>(() =>
+  membersDirectory.flatMap((member) =>
+    member.contributions.map((contribution) => ({
+      id: `${member.id}-${contribution.id}`,
+      memberId: member.id,
+      memberName: `${member.firstName} ${member.lastName}`,
+      membershipType: member.membershipType,
+      label: contribution.label,
+      amount: contribution.amount,
+      dueDate: contribution.dueDate,
+      status: contribution.status,
+      reminderCount: contribution.reminderCount,
+      lastReminderAt: contribution.lastReminderAt,
+    })),
+  ),
+);
+
+const paidTotal = computed(() =>
+  contributionRows.value
+    .filter((row) => row.status === 'paid')
+    .reduce((total, row) => total + row.amount, 0)
+    .toLocaleString('fr-FR', { minimumFractionDigits: 2, maximumFractionDigits: 2 }),
+);
+
+const pendingTotal = computed(() =>
+  contributionRows.value
+    .filter((row) => row.status === 'pending')
+    .reduce((total, row) => total + row.amount, 0)
+    .toLocaleString('fr-FR', { minimumFractionDigits: 2, maximumFractionDigits: 2 }),
+);
+
+const overdueTotal = computed(() =>
+  contributionRows.value
+    .filter((row) => row.status === 'overdue')
+    .reduce((total, row) => total + row.amount, 0)
+    .toLocaleString('fr-FR', { minimumFractionDigits: 2, maximumFractionDigits: 2 }),
+);
+
+const overdueItems = computed(() => contributionRows.value.filter((row) => row.status === 'overdue'));
+
+const reminderQueued = ref(false);
+
+function formatDate(date: string) {
+  return new Date(date).toLocaleDateString('fr-FR', {
+    day: '2-digit',
+    month: 'long',
+    year: 'numeric',
+  });
+}
+
+function badgeVariant(status: MemberContribution['status']): BadgeVariant {
+  switch (status) {
+    case 'paid':
+      return 'success';
+    case 'overdue':
+      return 'outline';
+    default:
+      return 'accent';
+  }
+}
+
+function badgeClass(status: MemberContribution['status']) {
+  if (status === 'overdue') {
+    return 'border-destructive/60 text-destructive';
+  }
+  if (status === 'pending') {
+    return 'border-accent/40 text-accent';
+  }
+  return '';
+}
+
+function badgeLabel(status: MemberContribution['status']) {
+  switch (status) {
+    case 'paid':
+      return 'Payée';
+    case 'overdue':
+      return 'En retard';
+    case 'pending':
+      return 'En attente';
+    default:
+      return status;
+  }
+}
+
+function navigateToMember(memberId: string) {
+  router.push({ name: 'members.detail', params: { memberId } });
+}
+
+function registerPayment(memberId: string, amount: number) {
+  router.push({
+    name: 'members.detail',
+    params: { memberId },
+    query: { paiement: amount.toFixed(2) },
+  });
+}
+
+function queueReminder(memberId: string) {
+  reminderQueued.value = true;
+  setTimeout(() => {
+    reminderQueued.value = false;
+  }, 3000);
+  if (focusedMemberId.value !== memberId) {
+    router.replace({ name: 'members.contributions', query: { focus: memberId } });
+  }
+}
+
+function generateReminderBatch() {
+  reminderQueued.value = true;
+  setTimeout(() => {
+    reminderQueued.value = false;
+  }, 3000);
+}
+</script>

--- a/apps/web/src/modules/members/views/MemberDetail.vue
+++ b/apps/web/src/modules/members/views/MemberDetail.vue
@@ -1,0 +1,477 @@
+<template>
+  <section v-if="member" class="space-y-8">
+    <header class="space-y-4">
+      <BaseBadge :variant="statusVariant(member.status)" :class="statusClass(member.status)">
+        {{ statusLabel(member.status) }}
+      </BaseBadge>
+      <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h1 class="text-3xl font-display font-semibold tracking-tight text-foreground sm:text-4xl">
+            Fiche membre · {{ member.firstName }} {{ member.lastName }}
+          </h1>
+          <p class="max-w-2xl text-sm text-muted-foreground">
+            Visualisez l'historique complet des cotisations, paiements et documents justificatifs liés à cet adhérent.
+          </p>
+        </div>
+        <div class="flex flex-wrap gap-2">
+          <BaseBadge v-for="tag in member.tags" :key="tag" variant="accent" class="capitalize">{{ tag }}</BaseBadge>
+        </div>
+      </div>
+    </header>
+
+    <div class="grid gap-5 lg:grid-cols-3">
+      <BaseCard>
+        <template #title>Coordonnées</template>
+        <template #description>Données de contact vérifiées pour vos relances et reçus.</template>
+        <ul class="space-y-2 text-sm text-muted-foreground">
+          <li class="flex items-center gap-2">
+            <span class="font-medium text-foreground">Email :</span>
+            <a :href="`mailto:${member.email}`" class="text-primary hover:underline">{{ member.email }}</a>
+          </li>
+          <li class="flex items-center gap-2">
+            <span class="font-medium text-foreground">Téléphone :</span>
+            <a :href="`tel:${member.phone}`" class="text-primary hover:underline">{{ member.phone }}</a>
+          </li>
+          <li class="flex gap-2">
+            <span class="font-medium text-foreground">Adresse :</span>
+            <span>{{ member.address }}</span>
+          </li>
+        </ul>
+      </BaseCard>
+
+      <BaseCard>
+        <template #title>Adhésion</template>
+        <template #description>Suivi des échéances et du statut de renouvellement.</template>
+        <dl class="space-y-2 text-sm text-muted-foreground">
+          <div class="flex justify-between">
+            <dt class="font-medium text-foreground">Type</dt>
+            <dd>{{ member.membershipType }}</dd>
+          </div>
+          <div class="flex justify-between">
+            <dt class="font-medium text-foreground">Adhérent depuis</dt>
+            <dd>{{ formatDate(member.joinDate) }}</dd>
+          </div>
+          <div class="flex justify-between">
+            <dt class="font-medium text-foreground">Prochaine échéance</dt>
+            <dd>{{ formatDate(member.nextRenewalDate) }}</dd>
+          </div>
+          <div class="flex justify-between">
+            <dt class="font-medium text-foreground">Solde à régulariser</dt>
+            <dd :class="member.outstandingBalance > 0 ? 'text-destructive font-semibold' : ''">
+              {{ member.outstandingBalance.toLocaleString('fr-FR', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) }} €
+            </dd>
+          </div>
+        </dl>
+      </BaseCard>
+
+      <BaseCard>
+        <template #title>Documents</template>
+        <template #description>Factures et reçus disponibles immédiatement.</template>
+        <ul class="space-y-2 text-sm text-muted-foreground">
+          <li v-for="invoice in member.invoices" :key="invoice.id" class="flex items-center justify-between">
+            <span class="truncate">{{ invoice.label }}</span>
+            <a
+              :href="invoice.downloadUrl"
+              class="text-primary hover:underline"
+              :download="`facture_${invoice.id}.pdf`"
+            >
+              Télécharger
+            </a>
+          </li>
+        </ul>
+      </BaseCard>
+    </div>
+
+    <div class="grid gap-6 lg:grid-cols-[2fr,1fr]">
+      <BaseCard>
+        <template #title>Historique des cotisations</template>
+        <template #description>Chaque cotisation est suivie avec son état et ses relances.</template>
+        <div class="overflow-hidden rounded-xl border border-outline/40">
+          <table class="min-w-full divide-y divide-outline/40 text-sm">
+            <thead class="bg-muted/50 text-left text-xs uppercase tracking-wide text-muted-foreground">
+              <tr>
+                <th class="px-4 py-3">Libellé</th>
+                <th class="px-4 py-3">Échéance</th>
+                <th class="px-4 py-3">Montant</th>
+                <th class="px-4 py-3">Statut</th>
+                <th class="px-4 py-3">Relances</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-outline/40 bg-surface">
+              <tr v-for="contribution in member.contributions" :key="contribution.id" class="hover:bg-muted/40">
+                <td class="px-4 py-3 font-medium text-foreground">{{ contribution.label }}</td>
+                <td class="px-4 py-3 text-muted-foreground">{{ formatDate(contribution.dueDate) }}</td>
+                <td class="px-4 py-3 text-muted-foreground">{{ contribution.amount.toFixed(2) }} €</td>
+                <td class="px-4 py-3">
+                  <BaseBadge :variant="contributionBadge(contribution.status)" :class="contributionClass(contribution.status)">
+                    {{ contributionLabel(contribution.status) }}
+                  </BaseBadge>
+                </td>
+                <td class="px-4 py-3 text-muted-foreground">
+                  <span v-if="contribution.reminderCount === 0">Aucune</span>
+                  <span v-else>
+                    {{ contribution.reminderCount }}
+                    <span v-if="contribution.lastReminderAt">
+                      · dernière le {{ formatDate(contribution.lastReminderAt) }}
+                    </span>
+                  </span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </BaseCard>
+
+      <BaseCard>
+        <template #title>Paiements enregistrés</template>
+        <template #description>Suivi des règlements affectés aux cotisations.</template>
+        <ul class="space-y-3 text-sm">
+          <li
+            v-for="payment in member.payments"
+            :key="payment.id"
+            class="rounded-xl border border-outline/40 bg-muted/20 p-3"
+          >
+            <div class="flex items-center justify-between">
+              <span class="font-semibold text-foreground">{{ payment.amount.toFixed(2) }} €</span>
+              <span class="text-xs text-muted-foreground">{{ formatDate(payment.date) }}</span>
+            </div>
+            <p class="text-xs text-muted-foreground">
+              {{ payment.method }} · Réf. {{ payment.reference }}
+            </p>
+            <a v-if="payment.receiptUrl" :href="payment.receiptUrl" class="text-xs text-primary hover:underline">
+              Télécharger le reçu
+            </a>
+            <p v-if="payment.note" class="mt-2 text-xs text-muted-foreground">{{ payment.note }}</p>
+          </li>
+        </ul>
+      </BaseCard>
+    </div>
+
+    <div class="grid gap-6 lg:grid-cols-2">
+      <BaseCard>
+        <template #title>Enregistrer un paiement</template>
+        <template #description>Lettrez immédiatement le règlement et mettez à jour le statut de la cotisation.</template>
+        <form class="space-y-4" @submit.prevent="submitPayment">
+          <div class="grid gap-3 sm:grid-cols-2">
+            <label class="text-sm font-medium text-foreground">
+              Montant (€)
+              <input
+                v-model.number="paymentForm.amount"
+                type="number"
+                step="0.01"
+                min="0"
+                required
+                class="mt-1 w-full rounded-lg border border-outline/40 bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
+              />
+            </label>
+            <label class="text-sm font-medium text-foreground">
+              Date de paiement
+              <input
+                v-model="paymentForm.date"
+                type="date"
+                required
+                class="mt-1 w-full rounded-lg border border-outline/40 bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
+              />
+            </label>
+          </div>
+          <div class="grid gap-3 sm:grid-cols-2">
+            <label class="text-sm font-medium text-foreground">
+              Méthode
+              <select
+                v-model="paymentForm.method"
+                class="mt-1 w-full rounded-lg border border-outline/40 bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
+              >
+                <option value="Carte">Carte</option>
+                <option value="Virement">Virement</option>
+                <option value="Espèces">Espèces</option>
+                <option value="Chèque">Chèque</option>
+              </select>
+            </label>
+            <label class="text-sm font-medium text-foreground">
+              Référence
+              <input
+                v-model="paymentForm.reference"
+                type="text"
+                placeholder="Référence bancaire"
+                required
+                class="mt-1 w-full rounded-lg border border-outline/40 bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
+              />
+            </label>
+          </div>
+          <label class="text-sm font-medium text-foreground">
+            Note interne
+            <textarea
+              v-model="paymentForm.note"
+              rows="3"
+              class="mt-1 w-full rounded-lg border border-outline/40 bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
+              placeholder="Ex : paiement reçu lors de la permanence du samedi"
+            ></textarea>
+          </label>
+          <div class="flex items-center justify-between gap-3">
+            <div class="text-xs text-muted-foreground">
+              Le paiement sera lettré automatiquement sur la prochaine cotisation en attente.
+            </div>
+            <BaseButton type="submit">Enregistrer le paiement</BaseButton>
+          </div>
+          <p
+            v-if="paymentSuccess"
+            data-testid="payment-success"
+            class="rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-700"
+          >
+            Paiement enregistré et cotisation mise à jour.
+          </p>
+        </form>
+      </BaseCard>
+
+      <BaseCard>
+        <template #title>Télécharger un reçu</template>
+        <template #description>Ajoutez un justificatif transmis par l'adhérent pour consolider l'historique.</template>
+        <form class="space-y-4" @submit.prevent="submitReceipt">
+          <label class="text-sm font-medium text-foreground">
+            Paiement concerné
+            <select
+              v-model="receiptForm.paymentId"
+              required
+              class="mt-1 w-full rounded-lg border border-outline/40 bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
+            >
+              <option disabled value="">Sélectionner un paiement</option>
+              <option v-for="payment in member.payments" :key="payment.id" :value="payment.id">
+                {{ formatDate(payment.date) }} · {{ payment.amount.toFixed(2) }} €
+              </option>
+            </select>
+          </label>
+          <label class="text-sm font-medium text-foreground">
+            Reçu PDF
+            <input
+              ref="receiptInput"
+              type="file"
+              accept="application/pdf"
+              required
+              class="mt-1 block w-full rounded-lg border border-dashed border-outline/60 bg-background px-3 py-8 text-center text-sm text-muted-foreground"
+              @change="handleReceiptChange"
+            />
+          </label>
+          <p v-if="uploadedReceiptName" class="text-xs text-muted-foreground">
+            Fichier sélectionné : {{ uploadedReceiptName }}
+          </p>
+          <div class="flex items-center justify-between gap-3">
+            <span class="text-xs text-muted-foreground">Le document sera disponible dans l'espace membre.</span>
+            <BaseButton type="submit" variant="secondary">Joindre le reçu</BaseButton>
+          </div>
+          <p
+            v-if="receiptSuccess"
+            data-testid="receipt-success"
+            class="rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-700"
+          >
+            Reçu enregistré et accessible dans le portail adhérent.
+          </p>
+        </form>
+      </BaseCard>
+    </div>
+  </section>
+
+  <section v-else class="space-y-6">
+    <BaseBadge variant="outline">Membre introuvable</BaseBadge>
+    <p class="text-sm text-muted-foreground">
+      Aucun membre ne correspond à cette référence. Retournez à la liste pour sélectionner un profil valide.
+    </p>
+    <BaseButton variant="outline" @click="goBack">Retour à la liste</BaseButton>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, reactive, ref } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+
+import BaseBadge from '@/components/ui/BaseBadge.vue';
+import BaseButton from '@/components/ui/BaseButton.vue';
+import BaseCard from '@/components/ui/BaseCard.vue';
+
+import type { MemberContribution, MemberProfile } from '../data';
+import { membersDirectory } from '../data';
+
+type ContributionStatus = MemberContribution['status'];
+
+type BadgeVariant = 'primary' | 'secondary' | 'accent' | 'outline' | 'success';
+
+const route = useRoute();
+const router = useRouter();
+
+const memberId = computed(() => route.params.memberId as string | undefined);
+
+const initialMember = computed(() =>
+  memberId.value ? membersDirectory.find((candidate) => candidate.id === memberId.value) ?? null : null,
+);
+
+const member = ref<MemberProfile | null>(
+  initialMember.value ? (JSON.parse(JSON.stringify(initialMember.value)) as MemberProfile) : null,
+);
+
+const defaultPendingContribution = initialMember.value?.contributions.find((contribution) => contribution.status !== 'paid');
+
+const paymentForm = reactive({
+  amount: defaultPendingContribution?.amount ?? initialMember.value?.outstandingBalance ?? 0,
+  date: new Date().toISOString().slice(0, 10),
+  method: 'Virement' as MemberProfile['payments'][number]['method'],
+  reference: '',
+  note: '',
+});
+
+const receiptForm = reactive<{ paymentId: string; file: File | null }>({
+  paymentId: member.value?.payments[0]?.id ?? '',
+  file: null,
+});
+
+const paymentSuccess = ref(false);
+const receiptSuccess = ref(false);
+const uploadedReceiptName = ref('');
+const receiptInput = ref<HTMLInputElement | null>(null);
+
+function formatDate(date: string) {
+  return new Date(date).toLocaleDateString('fr-FR', {
+    day: '2-digit',
+    month: 'long',
+    year: 'numeric',
+  });
+}
+
+function statusVariant(status: MemberProfile['status']): BadgeVariant {
+  switch (status) {
+    case 'A_JOUR':
+      return 'success';
+    case 'EN_RETARD':
+      return 'outline';
+    default:
+      return 'accent';
+  }
+}
+
+function statusClass(status: MemberProfile['status']) {
+  if (status === 'EN_RETARD') {
+    return 'border-destructive/60 text-destructive';
+  }
+  if (status === 'EN_ATTENTE') {
+    return 'border-accent/40 text-accent';
+  }
+  return '';
+}
+
+function statusLabel(status: MemberProfile['status']) {
+  switch (status) {
+    case 'A_JOUR':
+      return 'Cotisation à jour';
+    case 'EN_RETARD':
+      return 'Relance nécessaire';
+    case 'EN_ATTENTE':
+      return 'En attente de validation';
+    default:
+      return status;
+  }
+}
+
+function contributionBadge(status: ContributionStatus): BadgeVariant {
+  switch (status) {
+    case 'paid':
+      return 'success';
+    case 'overdue':
+      return 'outline';
+    default:
+      return 'accent';
+  }
+}
+
+function contributionClass(status: ContributionStatus) {
+  if (status === 'overdue') {
+    return 'border-destructive/60 text-destructive';
+  }
+  if (status === 'pending') {
+    return 'border-accent/40 text-accent';
+  }
+  return '';
+}
+
+function contributionLabel(status: ContributionStatus) {
+  switch (status) {
+    case 'paid':
+      return 'Payée';
+    case 'overdue':
+      return 'En retard';
+    case 'pending':
+      return 'En attente';
+    default:
+      return status;
+  }
+}
+
+function submitPayment() {
+  if (!member.value) {
+    return;
+  }
+
+  const paymentId = `pay-${Date.now()}`;
+  member.value.payments.unshift({
+    id: paymentId,
+    amount: Number(paymentForm.amount),
+    date: paymentForm.date,
+    method: paymentForm.method,
+    reference: paymentForm.reference,
+    note: paymentForm.note,
+    receiptUrl: undefined,
+  });
+
+  receiptForm.paymentId = paymentId;
+
+  const pendingContribution = member.value.contributions.find((contribution) => contribution.status !== 'paid');
+  if (pendingContribution) {
+    pendingContribution.status = 'paid';
+    pendingContribution.paymentDate = paymentForm.date;
+    pendingContribution.reminderCount = 0;
+    pendingContribution.lastReminderAt = undefined;
+    pendingContribution.receiptUrl = pendingContribution.receiptUrl ?? `/documents/recus/${paymentId}.pdf`;
+  }
+
+  member.value.lastPaymentDate = paymentForm.date;
+  member.value.outstandingBalance = Math.max(member.value.outstandingBalance - Number(paymentForm.amount), 0);
+  paymentForm.amount = 0;
+  paymentForm.reference = '';
+  paymentForm.note = '';
+  paymentSuccess.value = true;
+  setTimeout(() => {
+    paymentSuccess.value = false;
+  }, 4000);
+}
+
+function handleReceiptChange(event: Event) {
+  const input = event.target as HTMLInputElement;
+  const files = input.files;
+  receiptForm.file = files && files.length ? files[0] : null;
+  uploadedReceiptName.value = receiptForm.file ? receiptForm.file.name : '';
+}
+
+function submitReceipt() {
+  if (!member.value || !receiptForm.paymentId || !receiptForm.file) {
+    return;
+  }
+
+  const payment = member.value.payments.find((candidate) => candidate.id === receiptForm.paymentId);
+  if (!payment) {
+    return;
+  }
+
+  const generatedUrl = `/documents/recus/${receiptForm.file.name.replace(/\s+/g, '-').toLowerCase()}`;
+  payment.receiptUrl = generatedUrl;
+  receiptSuccess.value = true;
+  uploadedReceiptName.value = '';
+  receiptForm.file = null;
+  if (receiptInput.value) {
+    receiptInput.value.value = '';
+  }
+  setTimeout(() => {
+    receiptSuccess.value = false;
+  }, 4000);
+}
+
+function goBack() {
+  router.push({ name: 'members.list' });
+}
+</script>

--- a/apps/web/src/modules/members/views/MemberSelfService.vue
+++ b/apps/web/src/modules/members/views/MemberSelfService.vue
@@ -1,0 +1,253 @@
+<template>
+  <section class="space-y-8">
+    <header class="space-y-3">
+      <BaseBadge variant="secondary">Portail adhérent</BaseBadge>
+      <h1 class="text-3xl font-display font-semibold tracking-tight text-foreground sm:text-4xl">
+        Bienvenue {{ member.firstName }}
+      </h1>
+      <p class="max-w-2xl text-sm text-muted-foreground">
+        Consultez votre statut d'adhésion, vos factures et téléchargez vos reçus fiscaux en toute autonomie.
+      </p>
+    </header>
+
+    <div class="grid gap-5 lg:grid-cols-3">
+      <BaseCard>
+        <template #title>Statut de l'adhésion</template>
+        <template #description>Renouvellement prévu le {{ formatDate(member.nextRenewalDate) }}.</template>
+        <BaseBadge :variant="statusVariant(member.status)" :class="statusClass(member.status)">
+          {{ statusLabel(member.status) }}
+        </BaseBadge>
+      </BaseCard>
+      <BaseCard>
+        <template #title>Solde</template>
+        <template #description>Montant restant à régler sur vos cotisations.</template>
+        <p :class="member.outstandingBalance > 0 ? 'text-destructive' : 'text-foreground'" class="text-3xl font-semibold">
+          {{ member.outstandingBalance.toFixed(2) }} €
+        </p>
+      </BaseCard>
+      <BaseCard>
+        <template #title>Dernier paiement</template>
+        <template #description>Conservez la trace de vos règlements.</template>
+        <p class="text-3xl font-semibold text-foreground">{{ formatDate(member.lastPaymentDate ?? member.joinDate) }}</p>
+      </BaseCard>
+    </div>
+
+    <div class="grid gap-6 lg:grid-cols-[2fr,1fr]">
+      <BaseCard>
+        <template #title>Historique de cotisation</template>
+        <template #description>Retrouvez vos factures et statuts ligne par ligne.</template>
+        <div class="overflow-hidden rounded-xl border border-outline/40">
+          <table class="min-w-full divide-y divide-outline/40 text-sm">
+            <thead class="bg-muted/50 text-left text-xs uppercase tracking-wide text-muted-foreground">
+              <tr>
+                <th class="px-4 py-3">Libellé</th>
+                <th class="px-4 py-3">Échéance</th>
+                <th class="px-4 py-3">Montant</th>
+                <th class="px-4 py-3">Statut</th>
+                <th class="px-4 py-3">Document</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-outline/40 bg-surface">
+              <tr v-for="invoice in member.invoices" :key="invoice.id" class="hover:bg-muted/40">
+                <td class="px-4 py-3 font-medium text-foreground">{{ invoice.label }}</td>
+                <td class="px-4 py-3 text-muted-foreground">{{ formatDate(invoice.dueDate) }}</td>
+                <td class="px-4 py-3 text-muted-foreground">{{ invoice.amount.toFixed(2) }} €</td>
+                <td class="px-4 py-3">
+                  <BaseBadge :variant="invoiceBadge(invoice.status)" :class="invoiceClass(invoice.status)">
+                    {{ invoiceLabel(invoice.status) }}
+                  </BaseBadge>
+                </td>
+                <td class="px-4 py-3">
+                  <a
+                    :href="invoice.downloadUrl"
+                    class="text-sm text-primary hover:underline"
+                    :download="`facture_${invoice.id}.pdf`"
+                  >
+                    Télécharger la facture
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </BaseCard>
+
+      <BaseCard>
+        <template #title>Vos reçus</template>
+        <template #description>Disponibles pour vos déclarations fiscales.</template>
+        <ul class="space-y-3 text-sm">
+          <li
+            v-for="payment in member.payments"
+            :key="payment.id"
+            class="flex items-center justify-between rounded-xl border border-outline/40 bg-muted/20 px-4 py-3"
+          >
+            <div>
+              <p class="font-semibold text-foreground">{{ payment.amount.toFixed(2) }} €</p>
+              <p class="text-xs text-muted-foreground">{{ formatDate(payment.date) }} · {{ payment.method }}</p>
+            </div>
+            <a
+              v-if="payment.receiptUrl"
+              :href="payment.receiptUrl"
+              data-testid="download-receipt"
+              class="text-sm text-primary hover:underline"
+              :download="`recu_cotisation_${payment.id}.pdf`"
+            >
+              Télécharger
+            </a>
+            <span v-else class="text-xs text-muted-foreground">Reçu en cours d'émission</span>
+          </li>
+        </ul>
+      </BaseCard>
+    </div>
+
+    <BaseCard>
+      <template #title>Mettre à jour mes informations</template>
+      <template #description>Vous pouvez corriger vos coordonnées pour recevoir les notifications.</template>
+      <form class="grid gap-4 md:grid-cols-2" @submit.prevent="requestUpdate">
+        <label class="text-sm font-medium text-foreground">
+          Email
+          <input
+            v-model="updateForm.email"
+            type="email"
+            required
+            class="mt-1 w-full rounded-lg border border-outline/40 bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
+          />
+        </label>
+        <label class="text-sm font-medium text-foreground">
+          Téléphone
+          <input
+            v-model="updateForm.phone"
+            type="tel"
+            class="mt-1 w-full rounded-lg border border-outline/40 bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
+          />
+        </label>
+        <label class="md:col-span-2 text-sm font-medium text-foreground">
+          Adresse
+          <textarea
+            v-model="updateForm.address"
+            rows="3"
+            class="mt-1 w-full rounded-lg border border-outline/40 bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
+          ></textarea>
+        </label>
+        <div class="md:col-span-2 flex items-center justify-between gap-3">
+          <p class="text-xs text-muted-foreground">Une notification sera envoyée au trésorier pour validation.</p>
+          <BaseButton type="submit">Envoyer ma demande</BaseButton>
+        </div>
+        <p
+          v-if="updateSuccess"
+          class="md:col-span-2 rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-700"
+        >
+          Vos informations ont bien été transmises. Vous recevrez un email de confirmation.
+        </p>
+      </form>
+    </BaseCard>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { reactive, ref } from 'vue';
+
+import BaseBadge from '@/components/ui/BaseBadge.vue';
+import BaseButton from '@/components/ui/BaseButton.vue';
+import BaseCard from '@/components/ui/BaseCard.vue';
+
+import type { MemberInvoice, MemberProfile } from '../data';
+import { membersDirectory } from '../data';
+
+type BadgeVariant = 'primary' | 'secondary' | 'accent' | 'outline' | 'success';
+
+type InvoiceStatus = MemberInvoice['status'];
+
+const member = membersDirectory[0];
+
+const updateForm = reactive({
+  email: member.email,
+  phone: member.phone,
+  address: member.address,
+});
+
+const updateSuccess = ref(false);
+
+function formatDate(date: string) {
+  return new Date(date).toLocaleDateString('fr-FR', {
+    day: '2-digit',
+    month: 'long',
+    year: 'numeric',
+  });
+}
+
+function statusVariant(status: MemberProfile['status']): BadgeVariant {
+  switch (status) {
+    case 'A_JOUR':
+      return 'success';
+    case 'EN_RETARD':
+      return 'outline';
+    default:
+      return 'accent';
+  }
+}
+
+function statusClass(status: MemberProfile['status']) {
+  if (status === 'EN_RETARD') {
+    return 'border-destructive/60 text-destructive';
+  }
+  if (status === 'EN_ATTENTE') {
+    return 'border-accent/40 text-accent';
+  }
+  return '';
+}
+
+function statusLabel(status: MemberProfile['status']) {
+  switch (status) {
+    case 'A_JOUR':
+      return 'Cotisation à jour';
+    case 'EN_RETARD':
+      return 'Relance nécessaire';
+    case 'EN_ATTENTE':
+      return 'En attente de validation';
+    default:
+      return status;
+  }
+}
+
+function invoiceBadge(status: InvoiceStatus): BadgeVariant {
+  switch (status) {
+    case 'paid':
+      return 'success';
+    case 'overdue':
+      return 'outline';
+    default:
+      return 'accent';
+  }
+}
+
+function invoiceClass(status: InvoiceStatus) {
+  if (status === 'overdue') {
+    return 'border-destructive/60 text-destructive';
+  }
+  if (status === 'pending') {
+    return 'border-accent/40 text-accent';
+  }
+  return '';
+}
+
+function invoiceLabel(status: InvoiceStatus) {
+  switch (status) {
+    case 'paid':
+      return 'Payée';
+    case 'overdue':
+      return 'En retard';
+    case 'pending':
+      return 'En attente';
+    default:
+      return status;
+  }
+}
+
+function requestUpdate() {
+  updateSuccess.value = true;
+  setTimeout(() => {
+    updateSuccess.value = false;
+  }, 3000);
+}
+</script>

--- a/apps/web/src/modules/members/views/MembersList.vue
+++ b/apps/web/src/modules/members/views/MembersList.vue
@@ -1,41 +1,183 @@
 <template>
-  <section class="space-y-6">
-    <header class="space-y-2">
+  <section class="space-y-8">
+    <header class="space-y-3">
       <BaseBadge variant="secondary">Membres</BaseBadge>
       <h1 class="text-3xl font-display font-semibold tracking-tight text-foreground sm:text-4xl">
         Relations adhérents simplifiées
       </h1>
       <p class="max-w-2xl text-sm text-muted-foreground">
-        Centralisez les profils, gérez les cotisations et suivez les paiements pour maintenir une communauté engagée.
+        Centralisez les profils, gérez les cotisations et anticipez les relances depuis une vue unifiée.
       </p>
+      <div class="flex flex-wrap gap-3">
+        <BaseButton variant="outline" @click="goToContributions()">Suivi des cotisations</BaseButton>
+        <BaseButton variant="ghost" @click="goToSelfService()">Portail membre</BaseButton>
+      </div>
     </header>
 
-    <div class="grid gap-5 lg:grid-cols-2">
+    <div class="grid gap-5 md:grid-cols-3">
       <BaseCard>
-        <template #title>Vue membres</template>
-        <template #description>
-          Filtrez vos adhérents par statut, tarif réduit ou projet associé et exportez leurs fiches en un clic.
-        </template>
-        <template #actions>
-          <BaseButton variant="primary">Gérer les membres</BaseButton>
-        </template>
+        <template #title>Total adhérents actifs</template>
+        <template #description>Inscrits disposant d'une cotisation en cours de validité.</template>
+        <p class="text-3xl font-semibold text-foreground">{{ activeMembers }}</p>
       </BaseCard>
+      <BaseCard>
+        <template #title>Cotisations en retard</template>
+        <template #description>Montant cumulé à recouvrer sur les exercices en cours.</template>
+        <p class="text-3xl font-semibold text-destructive">{{ overdueAmount }} €</p>
+      </BaseCard>
+      <BaseCard>
+        <template #title>Relances programmées</template>
+        <template #description>Rappels à envoyer cette semaine aux adhérents concernés.</template>
+        <p class="text-3xl font-semibold text-foreground">{{ pendingReminders }}</p>
+      </BaseCard>
+    </div>
 
-      <BaseCard>
-        <template #title>Cotisations &amp; relances</template>
-        <template #description>
-          Configurez des modèles de cotisation, automatisez les relances et enregistrez les paiements avec lettrage comptable.
-        </template>
-        <template #actions>
-          <BaseButton variant="outline">Configurer les modèles</BaseButton>
-        </template>
-      </BaseCard>
+    <div class="overflow-hidden rounded-2xl border border-outline/50">
+      <table class="min-w-full divide-y divide-outline/60 text-sm">
+        <thead class="bg-muted/40 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          <tr>
+            <th scope="col" class="px-6 py-4">Membre</th>
+            <th scope="col" class="px-6 py-4">Type</th>
+            <th scope="col" class="px-6 py-4">Statut</th>
+            <th scope="col" class="px-6 py-4">Dernier paiement</th>
+            <th scope="col" class="px-6 py-4">Solde</th>
+            <th scope="col" class="px-6 py-4 text-right">Actions</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-outline/40 bg-surface">
+          <tr v-for="member in members" :key="member.id" class="hover:bg-muted/40">
+            <td class="px-6 py-4">
+              <div class="flex flex-col">
+                <button
+                  type="button"
+                  class="text-left font-medium text-foreground transition-colors hover:text-primary"
+                  @click="goToDetail(member.id)"
+                >
+                  {{ member.firstName }} {{ member.lastName }}
+                </button>
+                <span class="text-xs text-muted-foreground">{{ member.email }}</span>
+              </div>
+            </td>
+            <td class="px-6 py-4 text-muted-foreground">{{ member.membershipType }}</td>
+            <td class="px-6 py-4">
+              <BaseBadge :variant="statusVariant(member.status)" :class="statusClass(member.status)">
+                {{ statusLabel(member.status) }}
+              </BaseBadge>
+            </td>
+            <td class="px-6 py-4 text-muted-foreground">
+              <template v-if="member.lastPaymentDate">
+                {{ formatDate(member.lastPaymentDate) }}
+              </template>
+              <template v-else>
+                Aucun paiement enregistré
+              </template>
+            </td>
+            <td class="px-6 py-4 font-medium" :class="member.outstandingBalance > 0 ? 'text-destructive' : 'text-foreground'">
+              {{ member.outstandingBalance.toLocaleString('fr-FR', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) }} €
+            </td>
+            <td class="px-6 py-4">
+              <div class="flex justify-end gap-2">
+                <BaseButton
+                  variant="secondary"
+                  class="px-3 py-1.5 text-xs"
+                  @click="goToDetail(member.id)"
+                >
+                  Fiche
+                </BaseButton>
+                <BaseButton
+                  variant="outline"
+                  class="px-3 py-1.5 text-xs"
+                  @click="goToContributions(member.id)"
+                >
+                  Cotisations
+                </BaseButton>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
     </div>
   </section>
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue';
+import { useRouter } from 'vue-router';
+
 import BaseBadge from '@/components/ui/BaseBadge.vue';
 import BaseButton from '@/components/ui/BaseButton.vue';
 import BaseCard from '@/components/ui/BaseCard.vue';
+
+import { membersDirectory, type MemberProfile } from '../data';
+
+type StatusVariant = 'primary' | 'secondary' | 'accent' | 'outline' | 'success';
+
+const router = useRouter();
+
+const members = computed<MemberProfile[]>(() => membersDirectory);
+
+const activeMembers = computed(() => members.value.filter((member) => member.status !== 'EN_RETARD').length);
+const overdueAmount = computed(() =>
+  members.value
+    .filter((member) => member.outstandingBalance > 0)
+    .reduce((total, member) => total + member.outstandingBalance, 0)
+    .toLocaleString('fr-FR', { minimumFractionDigits: 2, maximumFractionDigits: 2 }),
+);
+const pendingReminders = computed(() =>
+  members.value.reduce((count, member) => count + member.contributions.filter((c) => c.status !== 'paid').length, 0),
+);
+
+function formatDate(date: string) {
+  return new Date(date).toLocaleDateString('fr-FR', {
+    day: '2-digit',
+    month: 'long',
+    year: 'numeric',
+  });
+}
+
+function statusVariant(status: MemberProfile['status']): StatusVariant {
+  switch (status) {
+    case 'A_JOUR':
+      return 'success';
+    case 'EN_RETARD':
+      return 'outline';
+    default:
+      return 'accent';
+  }
+}
+
+function statusLabel(status: MemberProfile['status']) {
+  switch (status) {
+    case 'A_JOUR':
+      return 'À jour';
+    case 'EN_RETARD':
+      return 'En retard';
+    case 'EN_ATTENTE':
+      return 'En attente';
+    default:
+      return status;
+  }
+}
+
+function statusClass(status: MemberProfile['status']) {
+  if (status === 'EN_RETARD') {
+    return 'border-destructive/60 text-destructive';
+  }
+  if (status === 'EN_ATTENTE') {
+    return 'border-accent/40 text-accent';
+  }
+  return '';
+}
+
+function goToDetail(memberId: string) {
+  router.push({ name: 'members.detail', params: { memberId } });
+}
+
+function goToContributions(memberId?: string) {
+  router.push({ name: 'members.contributions', query: memberId ? { focus: memberId } : undefined });
+}
+
+function goToSelfService() {
+  router.push({ name: 'members.selfService' });
+}
 </script>

--- a/apps/web/tests/members-flows.spec.ts
+++ b/apps/web/tests/members-flows.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test';
+
+const STORAGE_KEY = 'asso.auth.session';
+
+function seedSession(page) {
+  return page.addInitScript(({ storageKey }) => {
+    const expiresAt = Date.now() + 60 * 60 * 1000;
+    const session = {
+      accessToken: 'test-access',
+      refreshToken: 'test-refresh',
+      expiresAt,
+      user: {
+        id: 'user-2',
+        email: 'tresorier@example.org',
+        displayName: 'Trésorier Demo',
+        roles: ['TREASURER', 'VIEWER'],
+      },
+      organization: { id: 'org-1', name: 'Association Demo' },
+    };
+    window.localStorage.setItem(storageKey, JSON.stringify(session));
+  }, { storageKey: STORAGE_KEY });
+}
+
+test.beforeEach(async ({ page }) => {
+  await seedSession(page);
+});
+
+test('affiche une alerte de relance prioritaire', async ({ page }) => {
+  await page.goto('/membres/statuts-cotisations');
+
+  const banner = page.getByTestId('reminder-banner');
+  await expect(banner).toBeVisible();
+  await expect(banner).toContainText('relance(s) urgentes');
+});
+
+test('propose le téléchargement du reçu dans le portail adhérent', async ({ page }) => {
+  await page.goto('/portail/membre');
+
+  const receiptLink = page.getByTestId('download-receipt').first();
+  await expect(receiptLink).toBeVisible();
+  await expect(receiptLink).toHaveAttribute('download', /recu_cotisation_/);
+  await expect(receiptLink).toHaveAttribute('href', /\/documents\/recus\//);
+});


### PR DESCRIPTION
## Summary
- add shared member directory fixture used across the module
- implement member list, detail, contribution status, and self-service portal views with payment and receipt flows
- extend navigation and routing plus add Playwright coverage for reminder banner and receipt download

## Testing
- npm run test --workspace apps/web *(fails: Playwright browsers not installed in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68d63d02e614832392adc56956ca3541