### PR TITLE
feat(api): expose email notifier for transactional flows

### DIFF
--- a/apps/api/src/modules/notifications/__tests__/email-notifier.test.ts
+++ b/apps/api/src/modules/notifications/__tests__/email-notifier.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from 'vitest';
+import { type EmailService } from '../../../lib/email/service';
+import {
+  type ContributionReceiptEmailInput,
+  type ExportReadyAlertEmailInput,
+  type MembershipReminderEmailInput,
+  type SubsidyAlertEmailInput,
+  createEmailNotifier,
+} from '../email-notifier';
+
+describe('EmailNotifier', () => {
+  const createMocks = () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const emailService = {
+      send,
+      render: vi.fn(),
+      close: vi.fn(),
+    } as unknown as EmailService;
+
+    const notifier = createEmailNotifier(emailService);
+
+    return { notifier, send };
+  };
+
+  it('queues receipt emails for contributions', async () => {
+    const { notifier, send } = createMocks();
+    const input: ContributionReceiptEmailInput = {
+      to: 'camille@example.org',
+      organizationName: 'Association Bleu',
+      recipientName: 'Camille Dupont',
+      amount: '150,00 €',
+      receiptNumber: 'REC-2025-0012',
+      issuedAt: '12/02/2025',
+      fiscalYearLabel: 'Exercice 2024-2025',
+      downloadUrl: 'https://asso.test/receipts/REC-2025-0012.pdf',
+    };
+
+    await notifier.queueContributionReceipt(input);
+
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        template: 'receipt',
+        to: 'camille@example.org',
+        payload: expect.objectContaining({ receiptNumber: 'REC-2025-0012' }),
+      })
+    );
+  });
+
+  it('queues reminders for overdue memberships', async () => {
+    const { notifier, send } = createMocks();
+    const input: MembershipReminderEmailInput = {
+      to: 'lea@example.org',
+      organizationName: 'Association Bleu',
+      memberName: 'Léa Martin',
+      dueDate: '30/09/2025',
+      amount: '75,00 €',
+      paymentLink: 'https://asso.test/payments/cotisation',
+      supportContact: 'tresorier@asso.test',
+    };
+
+    await notifier.queueMembershipReminder(input);
+
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        template: 'reminder',
+        payload: expect.objectContaining({ paymentLink: 'https://asso.test/payments/cotisation' }),
+      })
+    );
+  });
+
+  it('queues subsidy alerts with default warning severity', async () => {
+    const { notifier, send } = createMocks();
+    const input: SubsidyAlertEmailInput = {
+      to: 'subventions@example.org',
+      organizationName: 'Association Bleu',
+      subsidyLabel: 'Plan de relance 2025',
+      message: 'Un justificatif est requis avant le 15 mai.',
+      actionUrl: 'https://asso.test/subsidies/plan-relance',
+    };
+
+    await notifier.queueSubsidyAlert(input);
+
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        template: 'alert',
+        payload: expect.objectContaining({
+          title: 'Suivi de subvention — Plan de relance 2025',
+          severity: 'warning',
+          actionLabel: 'Consulter le dossier',
+        }),
+      })
+    );
+  });
+
+  it('queues export-ready alerts with info severity and download CTA', async () => {
+    const { notifier, send } = createMocks();
+    const input: ExportReadyAlertEmailInput = {
+      to: 'tresorier@example.org',
+      organizationName: 'Association Bleu',
+      exportLabel: 'FEC 2024',
+      downloadUrl: 'https://asso.test/exports/fec-2024.csv',
+      expiresAt: '15/01/2026',
+    };
+
+    await notifier.queueExportReadyAlert(input);
+
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        template: 'alert',
+        payload: expect.objectContaining({
+          severity: 'info',
+          actionUrl: 'https://asso.test/exports/fec-2024.csv',
+          message: expect.stringContaining('avant le 15/01/2026'),
+        }),
+      })
+    );
+  });
+});

--- a/apps/api/src/modules/notifications/email-notifier.ts
+++ b/apps/api/src/modules/notifications/email-notifier.ts
@@ -1,0 +1,119 @@
+import type { EmailService } from '../../lib/email/service';
+import type {
+  AlertTemplateData,
+  ReminderTemplateData,
+  ReceiptTemplateData,
+} from '../../lib/email/templates';
+
+interface EmailEnvelope {
+  to: string;
+  cc?: string[];
+  bcc?: string[];
+  replyTo?: string;
+}
+
+export type ContributionReceiptEmailInput = EmailEnvelope & ReceiptTemplateData;
+export type MembershipReminderEmailInput = EmailEnvelope & ReminderTemplateData;
+
+export interface SubsidyAlertEmailInput extends EmailEnvelope {
+  organizationName: string;
+  subsidyLabel: string;
+  message: string;
+  actionUrl?: string;
+  actionLabel?: string;
+  severity?: NonNullable<AlertTemplateData['severity']>;
+}
+
+export interface ExportReadyAlertEmailInput extends EmailEnvelope {
+  organizationName: string;
+  exportLabel: string;
+  downloadUrl: string;
+  expiresAt?: string;
+}
+
+export interface EmailNotifier {
+  queueContributionReceipt(input: ContributionReceiptEmailInput): Promise<void>;
+  queueMembershipReminder(input: MembershipReminderEmailInput): Promise<void>;
+  queueSubsidyAlert(input: SubsidyAlertEmailInput): Promise<void>;
+  queueExportReadyAlert(input: ExportReadyAlertEmailInput): Promise<void>;
+}
+
+class DefaultEmailNotifier implements EmailNotifier {
+  constructor(private readonly emailService: EmailService) {}
+
+  async queueContributionReceipt(input: ContributionReceiptEmailInput): Promise<void> {
+    const { to, cc, bcc, replyTo, ...payload } = input;
+
+    await this.emailService.send({
+      to,
+      cc,
+      bcc,
+      replyTo,
+      template: 'receipt',
+      payload,
+    });
+  }
+
+  async queueMembershipReminder(input: MembershipReminderEmailInput): Promise<void> {
+    const { to, cc, bcc, replyTo, ...payload } = input;
+
+    await this.emailService.send({
+      to,
+      cc,
+      bcc,
+      replyTo,
+      template: 'reminder',
+      payload,
+    });
+  }
+
+  async queueSubsidyAlert(input: SubsidyAlertEmailInput): Promise<void> {
+    const { to, cc, bcc, replyTo, organizationName, subsidyLabel, message, actionUrl, actionLabel, severity } = input;
+
+    const payload: AlertTemplateData = {
+      organizationName,
+      title: `Suivi de subvention — ${subsidyLabel}`,
+      message,
+      severity: severity ?? 'warning',
+      actionUrl,
+      actionLabel: actionLabel ?? (actionUrl ? 'Consulter le dossier' : undefined),
+    };
+
+    await this.emailService.send({
+      to,
+      cc,
+      bcc,
+      replyTo,
+      template: 'alert',
+      payload,
+    });
+  }
+
+  async queueExportReadyAlert(input: ExportReadyAlertEmailInput): Promise<void> {
+    const { to, cc, bcc, replyTo, organizationName, exportLabel, downloadUrl, expiresAt } = input;
+
+    const payload: AlertTemplateData = {
+      organizationName,
+      title: `${exportLabel} prêt à télécharger`,
+      message: expiresAt
+        ? `L'export ${exportLabel} est maintenant disponible. Pensez à le télécharger avant le ${expiresAt}.`
+        : `L'export ${exportLabel} est maintenant disponible.`,
+      severity: 'info',
+      actionUrl: downloadUrl,
+      actionLabel: 'Télécharger l’export',
+    };
+
+    await this.emailService.send({
+      to,
+      cc,
+      bcc,
+      replyTo,
+      template: 'alert',
+      payload,
+    });
+  }
+}
+
+export function createEmailNotifier(emailService: EmailService): EmailNotifier {
+  return new DefaultEmailNotifier(emailService);
+}

--- a/apps/api/src/plugins/notifications.ts
+++ b/apps/api/src/plugins/notifications.ts
@@ -1,0 +1,16 @@
+import fp from 'fastify-plugin';
+import type { FastifyPluginAsync } from 'fastify';
+import { createEmailNotifier, type EmailNotifier } from '../modules/notifications/email-notifier';
+
+declare module 'fastify' {
+  interface FastifyInstance {
+    emailNotifier: EmailNotifier;
+  }
+}
+
+const notificationsPlugin: FastifyPluginAsync = fp(async (fastify) => {
+  const notifier = createEmailNotifier(fastify.emailService);
+  fastify.decorate('emailNotifier', notifier);
+});
+
+export default notificationsPlugin;

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -16,6 +16,7 @@ import memberReminderPlugin from './plugins/member-reminders';
 import objectStoragePlugin from './plugins/object-storage';
 import antivirusPlugin from './plugins/antivirus';
 import emailPlugin from './plugins/email';
+import notificationsPlugin from './plugins/notifications';
 import requestLoggerPlugin from './plugins/request-logger';
 import sentryPlugin from './plugins/sentry';
 import metricsPlugin from './plugins/metrics';
@@ -133,6 +134,7 @@ export async function buildServer(): Promise<FastifyInstance> {
   await app.register(memberReminderPlugin);
   await app.register(antivirusPlugin);
   await app.register(emailPlugin);
+  await app.register(notificationsPlugin);
   await app.register(objectStoragePlugin);
 
   if (config.METRICS_ENABLED) {


### PR DESCRIPTION
## Summary
- add an EmailNotifier helper that wraps the queue-backed email service for receipts, reminders, and alerts
- register a Fastify notifications plugin so cotisations, subventions, and exports can reuse the notifier
- cover the notifier with dedicated Vitest tests to protect template usage and payload shaping

## Testing
- npm test --workspaces --if-present *(fails: backend tests require Postgres and frontend Playwright browsers in CI)*

------
https://chatgpt.com/codex/tasks/task_e_68d657f9e3e8832387b378f472d21d08